### PR TITLE
chore: move dummy data from migrations to seeds to avoid prod seeding

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -11,6 +11,7 @@ export default {
 			database: process.env.DEV_DB_NAME,
 		},
 		migrations: { directory: './migrations' },
+		seeds: { directory: './seeds' },
 	},
 	staging: {
 		client: 'mysql2',
@@ -21,6 +22,7 @@ export default {
 			database: process.env.STAGING_DB_NAME,
 		},
 		migrations: { directory: './migrations' },
+		seeds: { directory: './seeds' },
 	},
 	production: {
 		client: 'mysql2',
@@ -35,5 +37,6 @@ export default {
 			stub: './src/lib/migration.stub.mjs',
 			extension: 'mjs',
 		},
+		seeds: { directory: './seeds' },
 	},
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
 		"migrate": "knex migrate:latest",
 		"migrate:status": "knex migrate:status",
 		"migrate:make": "knex migrate:make",
-		"migrate:rollback": "knex migrate:rollback"
+		"migrate:rollback": "knex migrate:rollback",
+		"seed": "knex seed:run",
+		"seed:dev": "knex seed:run",
+		"seed:make": "knex seed:make"
 	},
 	"lint-staged": {
 		"**/*.{js,jsx,ts,tsx,json,css,md}": [

--- a/seeds/01_dev_dummy_data.js
+++ b/seeds/01_dev_dummy_data.js
@@ -1,30 +1,34 @@
+/**
+ * Dev-only seed — idempotent, never runs in production.
+ * Run manually: `npm run seed` or `npm run seed:dev`
+ * Covers: roles_master, users (admin + rahul.sharma), employees, companies,
+ *         deliverable_categories, projects (5 with all tabs).
+ *
+ * This was previously a migration (20260819120000_seed_dummy_data.js) — moved
+ * to seeds/ so `knex migrate:latest` in prod never seeds dummy data.
+ */
 import bcrypt from 'bcrypt';
 
-// Seed dummy data for fresh/empty DBs — idempotent (no-ops if rows already exist).
-// Covers: roles_master, users (admin + regular), employees, companies, deliverable_categories, projects (5 with all tabs).
-export async function up(knex) {
+export async function seed(knex) {
+	if (process.env.NODE_ENV === 'production') {
+		console.log('[seed:01_dev_dummy_data] skipped in production');
+		return;
+	}
+
 	const hasUsers = await knex('users').count('* as cnt').first();
 	if (Number(hasUsers?.cnt || 0) > 0) {
-		// If any users exist, assume DB is not empty and skip projects seeding too
-		// but still ensure supporting masters exist.
 		console.log(
-			'[seed_dummy_data] users already exist, skipping user/project seed'
+			'[seed:01_dev_dummy_data] users already exist, checking masters/projects'
 		);
 	} else {
-		// Ensure roles
 		await ensureRoles(knex);
-		// Create users + employees
 		const { adminId, regularId } = await ensureUsers(knex);
-		// Ensure companies
 		await ensureCompanies(knex);
-		// Ensure deliverable categories
 		await ensureDeliverableCategories(knex);
-		// Seed projects with full tab payloads
 		await ensureProjects(knex, { adminId, regularId });
 		return;
 	}
 
-	// Even when users exist, ensure masters/projects exist if empty
 	await ensureCompanies(knex);
 	await ensureDeliverableCategories(knex);
 	const hasProjects = await knex('projects')
@@ -111,8 +115,6 @@ async function ensureRoles(knex) {
 async function ensureUsers(knex) {
 	const adminHash = await bcrypt.hash('Admin@123', 10);
 	const userHash = await bcrypt.hash('User@123', 10);
-
-	// Employees first (needed for users.employee_id FK)
 	const adminEmpId = await getOrCreateEmployee(knex, {
 		employee_id: 'EMP-001',
 		first_name: 'Admin',
@@ -133,14 +135,12 @@ async function ensureUsers(knex) {
 		phone: '8888888888',
 		status: 'active',
 	});
-
 	const superAdminRole = await knex('roles_master')
 		.where({ role_code: 'super_admin' })
 		.first();
 	const employeeRole = await knex('roles_master')
 		.where({ role_code: 'employee' })
 		.first();
-
 	const [adminId] = await knex('users').insert({
 		username: 'admin',
 		password_hash: adminHash,
@@ -154,7 +154,6 @@ async function ensureUsers(knex) {
 		account_type: 'employee',
 		isDelete: 0,
 	});
-
 	const [regularId] = await knex('users').insert({
 		username: 'rahul.sharma',
 		password_hash: userHash,
@@ -168,7 +167,6 @@ async function ensureUsers(knex) {
 		account_type: 'employee',
 		isDelete: 0,
 	});
-
 	return { adminId, regularId };
 }
 
@@ -250,8 +248,6 @@ async function ensureDeliverableCategories(knex) {
 async function ensureProjects(knex, { adminId, regularId }) {
 	const companies = await knex('companies').where({ isDelete: 0 }).select('id');
 	const companyId = companies[0]?.id || null;
-
-	const now = new Date().toISOString().slice(0, 10);
 	const teamJson = (aId, rId) =>
 		JSON.stringify([
 			{
@@ -271,7 +267,6 @@ async function ensureProjects(knex, { adminId, regularId }) {
 				role: 'Team Member',
 			},
 		]);
-
 	const activities = JSON.stringify([
 		{
 			id: 'act-001',
@@ -313,7 +308,6 @@ async function ensureProjects(knex, { adminId, regularId }) {
 			],
 		},
 	]);
-
 	const schedule = JSON.stringify({
 		locked: false,
 		rows: [
@@ -345,7 +339,6 @@ async function ensureProjects(knex, { adminId, regularId }) {
 			},
 		],
 	});
-
 	const docsReceived = JSON.stringify([
 		{
 			id: 1,
@@ -368,7 +361,6 @@ async function ensureProjects(knex, { adminId, regularId }) {
 			remarks: 'Hard copy',
 		},
 	]);
-
 	const docsIssued = JSON.stringify([
 		{
 			id: 101,
@@ -422,7 +414,6 @@ async function ensureProjects(knex, { adminId, regularId }) {
 			remarks: '',
 		},
 	]);
-
 	const handover = JSON.stringify([
 		{
 			id: 1,
@@ -439,7 +430,6 @@ async function ensureProjects(knex, { adminId, regularId }) {
 			hand_over: '',
 		},
 	]);
-
 	const manhours = JSON.stringify([
 		{
 			id: 1,
@@ -451,7 +441,6 @@ async function ensureProjects(knex, { adminId, regularId }) {
 			monthly_hours: { jan: 160, feb: 168, mar: 176, apr: 144 },
 		},
 	]);
-
 	const queryLog = JSON.stringify([
 		{
 			id: 1,
@@ -464,7 +453,6 @@ async function ensureProjects(knex, { adminId, regularId }) {
 			remark: 'Closed',
 		},
 	]);
-
 	const assumptions = JSON.stringify([
 		{
 			id: 1,
@@ -475,7 +463,6 @@ async function ensureProjects(knex, { adminId, regularId }) {
 			sr_no: 1,
 		},
 	]);
-
 	const lessons = JSON.stringify([
 		{
 			id: 1,
@@ -487,7 +474,6 @@ async function ensureProjects(knex, { adminId, regularId }) {
 			sr_no: 1,
 		},
 	]);
-
 	const kickoff = JSON.stringify([
 		{
 			id: 1,
@@ -502,7 +488,6 @@ async function ensureProjects(knex, { adminId, regularId }) {
 			mom_document: null,
 		},
 	]);
-
 	const internal = JSON.stringify([
 		{
 			id: 2,
@@ -517,7 +502,6 @@ async function ensureProjects(knex, { adminId, regularId }) {
 			mom_document: null,
 		},
 	]);
-
 	const inputDocsList = JSON.stringify([
 		{
 			id: 11,
@@ -535,7 +519,6 @@ async function ensureProjects(knex, { adminId, regularId }) {
 			subLot: 'A',
 		},
 	]);
-
 	const software = JSON.stringify([
 		{
 			id: 1,
@@ -547,7 +530,6 @@ async function ensureProjects(knex, { adminId, regularId }) {
 			notes: 'Structural analysis',
 		},
 	]);
-
 	const projects = [
 		{
 			name: 'Mumbai Metro Line 3 - Station Design',
@@ -678,7 +660,6 @@ async function ensureProjects(knex, { adminId, regularId }) {
 			updated_at: knex.fn.now(),
 		},
 	];
-
 	for (const p of projects) {
 		const base = {
 			...p,
@@ -701,20 +682,4 @@ async function ensureProjects(knex, { adminId, regularId }) {
 		};
 		await knex('projects').insert(base);
 	}
-}
-
-export async function down(knex) {
-	// Remove dummy projects by project_code; keep users/companies for manual recovery
-	await knex('projects')
-		.whereIn('project_code', [
-			'PROJ-001',
-			'PROJ-002',
-			'PROJ-003',
-			'PROJ-004',
-			'PROJ-005',
-		])
-		.del();
-	await knex('users').whereIn('username', ['admin', 'rahul.sharma']).del();
-	await knex('employees').whereIn('employee_id', ['EMP-001', 'EMP-002']).del();
-	// Keep companies/categories
 }

--- a/seeds/02_dev_leads_proposals.js
+++ b/seeds/02_dev_leads_proposals.js
@@ -1,10 +1,13 @@
 /**
- * Seed mock leads + proposals for empty DBs — idempotent.
- * Runs only if tables are empty (count === 0). Safe to re-run.
- * Reuses companies seeded in 20260819120000_seed_dummy_data.js.
+ * Dev-only seed — idempotent, never runs in production.
+ * Run manually: `npm run seed` (runs both) or `npx knex seed:run --specific 02_dev_leads_proposals.js`
+ * Requires companies from 01_dev_dummy_data.js (or existing DB).
  */
-
-export async function up(knex) {
+export async function seed(knex) {
+	if (process.env.NODE_ENV === 'production') {
+		console.log('[seed:02_dev_leads_proposals] skipped in production');
+		return;
+	}
 	const leadCnt = await knex('leads')
 		.where({ isDelete: 0 })
 		.count('* as cnt')
@@ -13,9 +16,8 @@ export async function up(knex) {
 	if (Number(leadCnt?.cnt || 0) === 0) {
 		await seedLeads(knex);
 	} else {
-		console.log('[seed_leads_proposals] leads already exist, skipping');
+		console.log('[seed:02] leads already exist, skipping');
 	}
-
 	const propCnt = await knex('proposals')
 		.where({ isDelete: 0 })
 		.count('* as cnt')
@@ -24,7 +26,7 @@ export async function up(knex) {
 	if (Number(propCnt?.cnt || 0) === 0) {
 		await seedProposals(knex);
 	} else {
-		console.log('[seed_leads_proposals] proposals already exist, skipping');
+		console.log('[seed:02] proposals already exist, skipping');
 	}
 }
 
@@ -36,7 +38,6 @@ async function seedLeads(knex) {
 	const getCompany = (name) =>
 		byName[name] ||
 		companies[0] || { id: null, company_name: name, city: 'Mumbai' };
-
 	const today = new Date();
 	const daysAgo = (n) => {
 		const d = new Date(today);
@@ -48,7 +49,6 @@ async function seedLeads(knex) {
 		d.setDate(d.getDate() + 7);
 		return d.toISOString().slice(0, 10);
 	};
-
 	const leads = [
 		{
 			company_id: getCompany('Mumbai Metro Rail Corporation').id,
@@ -209,11 +209,8 @@ async function seedLeads(knex) {
 			isDelete: 0,
 		},
 	];
-
-	for (const l of leads) {
-		await knex('leads').insert(l);
-	}
-	console.log(`[seed_leads_proposals] inserted ${leads.length} leads`);
+	for (const l of leads) await knex('leads').insert(l);
+	console.log(`[seed:02] inserted ${leads.length} leads`);
 }
 
 async function seedProposals(knex) {
@@ -222,8 +219,6 @@ async function seedProposals(knex) {
 		.select('id', 'company_name');
 	const byName = Object.fromEntries(companies.map((c) => [c.company_name, c]));
 	const getCompanyId = (name) => byName[name]?.id ?? null;
-
-	// Try to link some proposals to leads (if leads were just seeded, fetch them)
 	const leads = await knex('leads')
 		.where({ isDelete: 0 })
 		.select('id', 'company_name')
@@ -231,7 +226,6 @@ async function seedProposals(knex) {
 	const leadByCompany = Object.fromEntries(
 		leads.map((l) => [l.company_name, l.id])
 	);
-
 	const today = new Date();
 	const iso = (d) => d.toISOString().slice(0, 10);
 	const daysAgo = (n) => {
@@ -244,10 +238,8 @@ async function seedProposals(knex) {
 		d.setDate(d.getDate() + n);
 		return iso(d);
 	};
-
 	const month = String(today.getMonth() + 1).padStart(2, '0');
 	const year = today.getFullYear();
-
 	const proposals = [
 		{
 			proposal_id: `PROP-${year}-${month}-001`,
@@ -477,9 +469,7 @@ async function seedProposals(knex) {
 			isDelete: 0,
 		},
 	];
-
 	for (const p of proposals) {
-		// Avoid duplicate proposal_id (unique)
 		const exists = await knex('proposals')
 			.where({ proposal_id: p.proposal_id })
 			.first();
@@ -487,31 +477,6 @@ async function seedProposals(knex) {
 		await knex('proposals').insert(p);
 	}
 	console.log(
-		`[seed_leads_proposals] proposals seeding done (attempted ${proposals.length})`
+		`[seed:02] proposals seeding done (attempted ${proposals.length})`
 	);
-}
-
-export async function down(knex) {
-	await knex('leads')
-		.whereIn(
-			'lead_id',
-			['001-', '002-', '003-', '004-', '005-', '006-', '007-'].map((prefix) =>
-				knex.raw(`CONCAT(?, DATE_FORMAT(NOW(), '%m-%Y'))`, [prefix])
-			)
-		)
-		.del()
-		.catch(() => {});
-	// Fallback: delete by company_name + project_description pattern for seeded rows
-	await knex('proposals')
-		.where('proposal_id', 'like', 'PROP-%')
-		.whereIn('client_name', [
-			'Mumbai Metro Rail Corporation',
-			'Adani Power Ltd',
-			'L&T Construction',
-			'Godrej Properties',
-			'Reliance Industries - Jamnagar',
-			'Infosys - Hyderabad Campus',
-		])
-		.del()
-		.catch(() => {});
 }


### PR DESCRIPTION
- Delete migrations/20260819120000_seed_dummy_data.js and 20260819140000_seed_leads_proposals.js (dummy data should never run via migrate:latest in prod)
- Add seeds/01_dev_dummy_data.js and seeds/02_dev_leads_proposals.js (idempotent, guarded with NODE_ENV === 'production' skip)
- knexfile.js: add seeds.directory for all envs
- package.json: add npm run seed / seed:dev / seed:make scripts

Better way: \migrate:latest\ is for schema only and runs automatically on deploy. Dummy data belongs in \seeds/\ which only runs via explicit \knex seed:run\ (\ pm run seed\) in dev. Migrating dummy data risks polluting prod with test users (admin/Admin@123) and fake projects/leads. Guard + opt-in seeds prevent that.

To clean dev DB history after pull: \DELETE FROM knex_migrations WHERE name IN ('20260819120000_seed_dummy_data.js','20260819140000_seed_leads_proposals.js')\ if you want migrate:status clean, or just leave — data remains, future migrates unaffected. Re-seed anytime with \ pm run seed\.