### PR TITLE
feat: leave application system with approval workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,19 +21,19 @@ This block is written and re-added by `next dev` — verify at `node_modules/nex
 
 ## Commands
 
-| Task          | Command                                                                                                                 |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Dev           | `npm run dev` (Turbopack is the default bundler in Next 16)                                                             |
-| Build / Start | `npm run build` (strict) then `npm run start`                                                                           |
-| Lint          | `npm run lint` (ESLint 9 flat, `src` + `scripts` only)                                                                  |
-| Format        | `npm run format` (Prettier: tabs, width 2, single-quote) — pre-commit runs `lint-staged: prettier --write` via Husky v9 |
-| Typecheck     | `npx tsc --noEmit` (no npm script)                                                                                      |
-| Test (watch)  | `npm test`                                                                                                              |
-| Test (once)   | `npm run test:run`                                                                                                      |
-| Coverage      | `npm run test:coverage`                                                                                                 |
-| Single file   | `npx vitest run src/__tests__/utils/money.test.ts`                                                                      |
-| Single name   | `npx vitest run -t "ensurePermission"`                                                                                  |
-| Migrations    | `npm run migrate` / `migrate:status` / `migrate:rollback` / `migrate:make -- <name>`                                    |
+| Task          | Command                                                                                                                                                                                  |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Dev           | `npm run dev` (Turbopack is the default bundler in Next 16)                                                                                                                              |
+| Build / Start | `npm run build` (strict) then `npm run start`                                                                                                                                            |
+| Lint          | `npm run lint` (ESLint 9 flat, `src` + `scripts` only)                                                                                                                                   |
+| Format        | `npm run format` (Prettier: tabs, width 2, single-quote) — pre-commit runs `lint-staged: prettier --write` via Husky v9                                                                  |
+| Typecheck     | `npx tsc --noEmit` (no npm script)                                                                                                                                                       |
+| Test (watch)  | `npm test`                                                                                                                                                                               |
+| Test (once)   | `npm run test:run`                                                                                                                                                                       |
+| Coverage      | `npm run test:coverage`                                                                                                                                                                  |
+| Single file   | `npx vitest run src/__tests__/utils/money.test.ts`                                                                                                                                       |
+| Single name   | `npx vitest run -t "ensurePermission"`                                                                                                                                                   |
+| Migrations    | `npm run migrate` / `migrate:status` / `migrate:rollback` / `migrate:make -- <name>` — prod DB: `migrate:prod` (+ `:status` / `:rollback`); plain `npm run migrate` targets **dev** only |
 
 Order that matters: `lint` → `npx tsc --noEmit` → `npm run test:run` before pushing; `npm run build` is the final gate.
 

--- a/migrations/20260825120000_create_leave_system.js
+++ b/migrations/20260825120000_create_leave_system.js
@@ -1,0 +1,189 @@
+/**
+ * Leave Application System
+ *
+ * - leave_types        : master list (code maps to payroll / employee_attendance
+ *                        status codes PL | CL | SL | EL | UL | LWP so approvals
+ *                        feed salary math correctly)
+ * - leave_applications : employee requests + admin review workflow
+ * - employee_leaves    : per-year balance ledger. Column names intentionally
+ *                        match the existing reader in
+ *                        src/app/api/users/[id]/attendance/route.js which
+ *                        already probes this table (employee_id, year,
+ *                        total_leaves, used_leaves).
+ *
+ * Also grants leaves:* permission keys to existing roles_master entries.
+ */
+
+const SEED_TYPES = [
+	// name, code, is_paid, annual quota, consumes balance
+	['Privilege Leave', 'PL', 1, 21, 1],
+	['Casual Leave', 'CL', 1, 12, 1],
+	['Sick Leave', 'SL', 1, 7, 1],
+	['Earned Leave', 'EL', 1, 15, 1],
+	['Loss of Pay', 'LWP', 0, 0, 0],
+	['Unpaid Leave', 'UL', 0, 0, 0],
+];
+
+// role_code -> permission actions granted on the leaves resource
+const ROLE_GRANTS = {
+	super_admin: ['read', 'create', 'update', 'delete', 'approve'],
+	project_manager: ['read', 'create', 'approve'],
+	employee: ['read', 'create'],
+};
+
+function grantKeysFor(roleCode) {
+	const actions =
+		ROLE_GRANTS[roleCode] ||
+		// Unknown roles fall back to the same baseline as "employee"
+		ROLE_GRANTS.employee;
+	return actions.map((action) => `leaves:${action}`);
+}
+
+function parsePermissions(raw) {
+	// mysql2/knex may deliver this LONGTEXT column already JSON-parsed.
+	if (!raw) return [];
+	if (Array.isArray(raw)) return raw.filter((k) => typeof k === 'string');
+	if (typeof raw === 'object') {
+		return Object.values(raw).filter((k) => typeof k === 'string');
+	}
+	try {
+		const parsed = JSON.parse(raw);
+		return Array.isArray(parsed)
+			? parsed.filter((k) => typeof k === 'string')
+			: [];
+	} catch (_) {
+		return [];
+	}
+}
+
+async function grantLeavesPermissions(knex) {
+	const roles = await knex
+		.select('id', 'role_code', 'permissions')
+		.from('roles_master');
+
+	for (const role of roles) {
+		const current = parsePermissions(role.permissions);
+		const merged = new Set([...current, ...grantKeysFor(role.role_code)]);
+		const next = Array.from(merged);
+
+		if (next.length !== current.length) {
+			await knex('roles_master')
+				.where({ id: role.id })
+				.update({ permissions: JSON.stringify(next) });
+		}
+	}
+}
+
+async function revokeLeavesPermissions(knex) {
+	const roles = await knex
+		.select('id', 'role_code', 'permissions')
+		.from('roles_master');
+
+	for (const role of roles) {
+		let current = [];
+		try {
+			current = JSON.parse(role.permissions || '[]');
+			if (!Array.isArray(current)) current = [];
+		} catch (_) {
+			current = [];
+		}
+
+		const revoked = current.filter(
+			(key) => typeof key !== 'string' || !key.startsWith('leaves:')
+		);
+
+		if (revoked.length !== current.length) {
+			await knex('roles_master')
+				.where({ id: role.id })
+				.update({ permissions: JSON.stringify(revoked) });
+		}
+	}
+}
+
+export async function up(knex) {
+	await knex.raw(`
+    CREATE TABLE IF NOT EXISTS leave_types (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      name VARCHAR(100) NOT NULL,
+      code VARCHAR(10) NOT NULL COMMENT 'Matches payroll/attendance status codes PL CL SL EL UL LWP',
+      description VARCHAR(255) DEFAULT NULL,
+      is_paid TINYINT(1) NOT NULL DEFAULT 1,
+      default_annual_quota DECIMAL(5,1) NOT NULL DEFAULT 0.0,
+      requires_balance TINYINT(1) NOT NULL DEFAULT 1 COMMENT '0 for LOP-type leaves that draw no quota',
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      isDelete TINYINT(1) NOT NULL DEFAULT 0,
+      deleted_at TIMESTAMP NULL DEFAULT NULL,
+      deleted_by INT NULL DEFAULT NULL,
+      active_code VARCHAR(10)
+        GENERATED ALWAYS AS (IF(isDelete = 0, code, NULL)) STORED,
+      UNIQUE KEY uq_active_leave_type_code (active_code),
+      KEY idx_isDelete (isDelete)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  `);
+
+	await knex.raw(`
+    CREATE TABLE IF NOT EXISTS leave_applications (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      user_id INT NOT NULL COMMENT 'Applicant (users.id)',
+      leave_type_id INT NOT NULL,
+      start_date DATE NOT NULL,
+      end_date DATE NOT NULL,
+      half_day TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'Only allowed when start_date = end_date',
+      duration_days DECIMAL(5,1) NOT NULL DEFAULT 1.0,
+      reason TEXT DEFAULT NULL,
+      status VARCHAR(20) NOT NULL DEFAULT 'pending'
+        COMMENT 'pending | approved | rejected (VARCHAR not ENUM per house convention)',
+      reviewed_by INT NULL DEFAULT NULL,
+      reviewed_at DATETIME NULL DEFAULT NULL,
+      review_notes TEXT DEFAULT NULL COMMENT 'Admin comments on approval/rejection',
+      written_attendance LONGTEXT DEFAULT NULL
+        COMMENT 'Audit trail for approval side-effects: {attendance:[{date,prev_status}],balances:[{leave_type_id,year,days}]}'
+        CHECK (written_attendance IS NULL OR json_valid(written_attendance)),
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+      isDelete TINYINT(1) NOT NULL DEFAULT 0,
+      KEY idx_leave_user (user_id),
+      KEY idx_leave_status (status),
+      KEY idx_leave_dates (start_date, end_date),
+      KEY idx_isDelete (isDelete),
+      CONSTRAINT fk_leave_app_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+      CONSTRAINT fk_leave_app_reviewer FOREIGN KEY (reviewed_by) REFERENCES users (id) ON DELETE SET NULL,
+      CONSTRAINT fk_leave_app_type FOREIGN KEY (leave_type_id) REFERENCES leave_types (id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  `);
+
+	await knex.raw(`
+    CREATE TABLE IF NOT EXISTS employee_leaves (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      employee_id INT NOT NULL COMMENT 'employees.id — matches the legacy reader contract',
+      leave_type_id INT NOT NULL,
+      year SMALLINT NOT NULL,
+      total_leaves DECIMAL(5,1) NOT NULL DEFAULT 0.0,
+      used_leaves DECIMAL(5,1) NOT NULL DEFAULT 0.0,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+      UNIQUE KEY uq_emp_type_year (employee_id, leave_type_id, year),
+      CONSTRAINT fk_emp_leaves_employee FOREIGN KEY (employee_id) REFERENCES employees (id) ON DELETE CASCADE,
+      CONSTRAINT fk_emp_leaves_type FOREIGN KEY (leave_type_id) REFERENCES leave_types (id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  `);
+
+	// Seed standard leave types (idempotent on code)
+	for (const [name, code, isPaid, quota, requiresBalance] of SEED_TYPES) {
+		await knex.raw(
+			`INSERT INTO leave_types (name, code, is_paid, default_annual_quota, requires_balance)
+       SELECT ?, ?, ?, ?, ?
+       WHERE NOT EXISTS (SELECT 1 FROM leave_types WHERE code = ?)`,
+			[name, code, isPaid, quota, requiresBalance, code]
+		);
+	}
+
+	await grantLeavesPermissions(knex);
+}
+
+export async function down(knex) {
+	await revokeLeavesPermissions(knex);
+	await knex.raw('DROP TABLE IF EXISTS employee_leaves');
+	await knex.raw('DROP TABLE IF EXISTS leave_applications');
+	await knex.raw('DROP TABLE IF EXISTS leave_types');
+}

--- a/migrations/20260825140000_restore_role_permissions_and_grant_leaves.js
+++ b/migrations/20260825140000_restore_role_permissions_and_grant_leaves.js
@@ -1,0 +1,115 @@
+/**
+ * Corrective migration for roles_master.permissions.
+ *
+ * Background: 20260825120000_create_leave_system.js merged leaves:* grants
+ * into roles_master.permissions, but mysql2/knex delivers that LONGTEXT
+ * column ALREADY JSON-PARSED (typeof === 'object'). The old merge code ran
+ * JSON.parse() on the array, which throws, silently treating every role's
+ * existing permissions as empty — so each role ended up holding ONLY its
+ * leaves:* keys.
+ *
+ * This migration restores the canonical baseline arrays from
+ * seeds/01_dev_dummy_data.js (union leaves grants included) and merges with
+ * whatever is currently stored, defensively handling BOTH shapes
+ * (string or pre-parsed object).
+ */
+
+// Canonical baseline permissions from seeds/01_dev_dummy_data.js
+const BASELINE_PERMISSIONS = {
+	super_admin: [
+		'projects:read',
+		'projects:create',
+		'projects:update',
+		'projects:delete',
+		'projects:close',
+		'leads:read',
+		'leads:create',
+		'leads:update',
+		'leads:delete',
+		'quotations:read',
+		'quotations:update',
+		'purchase_orders:read',
+		'purchase_orders:update',
+		'invoices:read',
+		'invoices:update',
+		'employees:read',
+		'employees:update',
+		'users:read',
+		'users:create',
+		'users:update',
+		'users:delete',
+		'companies:read',
+		'companies:update',
+		'reports:read',
+	],
+	project_manager: [
+		'projects:read',
+		'projects:update',
+		'projects:close',
+		'leads:read',
+		'quotations:read',
+		'purchase_orders:read',
+		'invoices:read',
+		'reports:read',
+	],
+	employee: ['projects:read', 'leads:read'],
+};
+
+const LEAVES_GRANTS = {
+	super_admin: [
+		'leaves:read',
+		'leaves:create',
+		'leaves:update',
+		'leaves:delete',
+		'leaves:approve',
+	],
+	project_manager: ['leaves:read', 'leaves:create', 'leaves:approve'],
+	employee: ['leaves:read', 'leaves:create'],
+};
+
+/** Parse a permissions value that may arrive as a JSON string OR an
+ *  already-parsed array (mysql2/knex auto-parse behaviour). */
+function parsePermissions(raw) {
+	if (!raw) return [];
+	if (Array.isArray(raw)) return raw.filter((k) => typeof k === 'string');
+	if (typeof raw === 'object') {
+		return Object.values(raw).filter((k) => typeof k === 'string');
+	}
+	try {
+		const parsed = JSON.parse(raw);
+		return Array.isArray(parsed)
+			? parsed.filter((k) => typeof k === 'string')
+			: [];
+	} catch (_) {
+		return [];
+	}
+}
+
+export async function up(knex) {
+	const roles = await knex
+		.select('id', 'role_code', 'permissions')
+		.from('roles_master');
+
+	for (const role of roles) {
+		const baseline =
+			BASELINE_PERMISSIONS[role.role_code] ?? BASELINE_PERMISSIONS.employee;
+		const grants = LEAVES_GRANTS[role.role_code] ?? LEAVES_GRANTS.employee;
+
+		const current = parsePermissions(role.permissions);
+		const next = Array.from(
+			new Set([
+				...baseline,
+				...current.filter((k) => !k.startsWith('leaves:')),
+				...grants,
+			])
+		);
+
+		await knex('roles_master')
+			.where({ id: role.id })
+			.update({ permissions: JSON.stringify(next) });
+	}
+}
+
+export async function down(knex) {
+	// No-op: restoring lost baseline data must not be reversible.
+}

--- a/migrations/20260826080000_grant_leave_management_to_admin_roles.js
+++ b/migrations/20260826080000_grant_leave_management_to_admin_roles.js
@@ -1,0 +1,71 @@
+/**
+ * Grant leave-management actions to production's admin role.
+ *
+ * Production uses role codes unlike dev (e.g. 'ADMIN', 'MD', 'ENG_HEAD'),
+ * so the baseline grants in 20260825120000 fell back to read/create for
+ * everything and nobody could approve leaves. This adds the full
+ * management set (update/delete/approve) to admin-coded roles.
+ *
+ * Broader approver roles (managers, department heads) can be granted from
+ * the Roles master UI once admins decide the approval chain.
+ */
+
+const MANAGEMENT_ACTIONS = ['update', 'delete', 'approve'];
+
+function parsePermissions(raw) {
+	// mysql2/knex may deliver this LONGTEXT column already JSON-parsed.
+	if (!raw) return [];
+	if (Array.isArray(raw)) return raw.filter((k) => typeof k === 'string');
+	if (typeof raw === 'object') {
+		return Object.values(raw).filter((k) => typeof k === 'string');
+	}
+	try {
+		const parsed = JSON.parse(raw);
+		return Array.isArray(parsed)
+			? parsed.filter((k) => typeof k === 'string')
+			: [];
+	} catch (_) {
+		return [];
+	}
+}
+
+export async function up(knex) {
+	const admins = await knex('roles_master')
+		.select('id', 'role_code', 'permissions')
+		.whereRaw('LOWER(role_code) LIKE ?', ['%admin%']);
+
+	for (const role of admins) {
+		const current = parsePermissions(role.permissions);
+		const merged = new Set([
+			...current,
+			...MANAGEMENT_ACTIONS.map((action) => `leaves:${action}`),
+		]);
+		const next = Array.from(merged);
+
+		if (next.length !== current.length) {
+			await knex('roles_master')
+				.where({ id: role.id })
+				.update({ permissions: JSON.stringify(next) });
+		}
+	}
+}
+
+export async function down(knex) {
+	const admins = await knex('roles_master')
+		.select('id', 'role_code', 'permissions')
+		.whereRaw('LOWER(role_code) LIKE ?', ['%admin%']);
+
+	for (const role of admins) {
+		const current = parsePermissions(role.permissions);
+		const next = current.filter(
+			(key) =>
+				!['leaves:update', 'leaves:delete', 'leaves:approve'].includes(key)
+		);
+
+		if (next.length !== current.length) {
+			await knex('roles_master')
+				.where({ id: role.id })
+				.update({ permissions: JSON.stringify(next) });
+		}
+	}
+}

--- a/migrations/20260826100000_grant_leaves_self_service_to_roleless_users.js
+++ b/migrations/20260826100000_grant_leaves_self_service_to_roleless_users.js
@@ -1,0 +1,87 @@
+/**
+ * Self-service leaves access for users without an assigned role.
+ *
+ * Production finding: every non-super-admin user has users.role_id NULL,
+ * so role-based grants (roles_master.permissions) never reach them and any
+ * permission check fails (403) — including the new /api/leaves endpoints.
+ *
+ * Assigning real roles is an organisational decision; until then this grants
+ * leaves:read + leaves:create directly through the users.permissions
+ * override channel to active, non-super-admin, role-less accounts.
+ *
+ * Idempotent and shape-safe (permissions may arrive as string OR array —
+ * see 20260825120000_create_leave_system.js).
+ */
+
+const SELF_SERVICE_KEYS = ['leaves:read', 'leaves:create'];
+
+function parsePermissions(raw) {
+	if (!raw) return [];
+	if (Array.isArray(raw)) return raw.filter((k) => typeof k === 'string');
+	if (typeof raw === 'object') {
+		return Object.values(raw).filter((k) => typeof k === 'string');
+	}
+	try {
+		const parsed = JSON.parse(raw);
+		return Array.isArray(parsed)
+			? parsed.filter((k) => typeof k === 'string')
+			: [];
+	} catch (_) {
+		return [];
+	}
+}
+
+export async function up(knex) {
+	const users = await knex('users')
+		.select('id', 'permissions')
+		.whereNull('role_id')
+		.where({ isDelete: 0 })
+		.andWhere(function () {
+			this.where('is_super_admin', 0).orWhereNull('is_super_admin');
+		})
+		.andWhere(function () {
+			this.where('is_active', 1).orWhereNull('is_active');
+		})
+		.andWhere(function () {
+			this.where('status', 'active').orWhereNull('status');
+		});
+
+	let updated = 0;
+	for (const user of users) {
+		const current = parsePermissions(user.permissions);
+		const merged = new Set([...current, ...SELF_SERVICE_KEYS]);
+		const next = Array.from(merged);
+
+		if (next.length !== current.length) {
+			await knex('users')
+				.where({ id: user.id })
+				.update({ permissions: JSON.stringify(next) });
+			updated++;
+		}
+	}
+	console.log(
+		`grant_leaves_self_service: ${updated} of ${users.length} role-less users updated`
+	);
+}
+
+export async function down(knex) {
+	const users = await knex('users')
+		.select('id', 'permissions')
+		.whereNull('role_id')
+		.where({ isDelete: 0 })
+		.andWhere(function () {
+			this.where('is_super_admin', 0).orWhereNull('is_super_admin');
+		});
+
+	for (const user of users) {
+		const current = parsePermissions(user.permissions);
+		if (current.length === 0) continue;
+		const next = current.filter((k) => !SELF_SERVICE_KEYS.includes(k));
+
+		if (next.length !== current.length) {
+			await knex('users')
+				.where({ id: user.id })
+				.update({ permissions: JSON.stringify(next) });
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
 				"@types/react": "^19.2.18",
 				"@types/react-dom": "^19.2.5",
 				"@vitejs/plugin-react": "^6.0.2",
+				"cross-env": "^10.1.0",
 				"eslint": "^9",
 				"eslint-config-next": "^16.3.2",
 				"husky": "^9.1.7",
@@ -628,6 +629,13 @@
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
+		},
+		"node_modules/@epic-web/invariant": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+			"integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@eslint-community/eslint-utils": {
 			"version": "4.9.1",
@@ -6303,6 +6311,24 @@
 			},
 			"engines": {
 				"node": ">= 10"
+			}
+		},
+		"node_modules/cross-env": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+			"integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@epic-web/invariant": "^1.0.0",
+				"cross-spawn": "^7.0.6"
+			},
+			"bin": {
+				"cross-env": "dist/bin/cross-env.js",
+				"cross-env-shell": "dist/bin/cross-env-shell.js"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
 		"migrate:status": "knex migrate:status",
 		"migrate:make": "knex migrate:make",
 		"migrate:rollback": "knex migrate:rollback",
+		"migrate:prod": "cross-env NODE_ENV=production knex migrate:latest",
+		"migrate:prod:status": "cross-env NODE_ENV=production knex migrate:status",
+		"migrate:prod:rollback": "cross-env NODE_ENV=production knex migrate:rollback",
 		"seed": "knex seed:run",
 		"seed:dev": "knex seed:run",
 		"seed:make": "knex seed:make"
@@ -83,6 +86,7 @@
 		"@types/react": "^19.2.18",
 		"@types/react-dom": "^19.2.5",
 		"@vitejs/plugin-react": "^6.0.2",
+		"cross-env": "^10.1.0",
 		"eslint": "^9",
 		"eslint-config-next": "^16.3.2",
 		"husky": "^9.1.7",

--- a/src/__tests__/api/leaves/[id]/route.test.ts
+++ b/src/__tests__/api/leaves/[id]/route.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock DB + auth BEFORE dynamic imports (Vitest hoists mocks)
+const mockExecute = vi.fn();
+const mockConn = { execute: mockExecute, release: vi.fn() };
+
+vi.mock('@/utils/database', () => ({
+	dbConnect: vi.fn().mockResolvedValue(mockConn),
+	withTransaction: vi.fn((fn) => fn(mockConn)),
+}));
+
+const mockEnsurePermission = vi.fn().mockResolvedValue({
+	authorized: true,
+	user: { id: 1, is_super_admin: true },
+});
+const mockGetCurrentUser = vi
+	.fn()
+	.mockResolvedValue({ id: 1, is_super_admin: true });
+vi.mock('@/utils/api-permissions', () => ({
+	ensurePermission: (...args) => mockEnsurePermission(...args),
+	getCurrentUser: (...args) => mockGetCurrentUser(...args),
+	RESOURCES: { LEAVES: 'leaves' },
+	PERMISSIONS: {
+		READ: 'read',
+		CREATE: 'create',
+		UPDATE: 'update',
+		DELETE: 'delete',
+		APPROVE: 'approve',
+	},
+}));
+
+vi.mock('@/utils/activity-logger', () => ({
+	logActivity: vi.fn(),
+}));
+
+const { PATCH, DELETE } = await import('@/app/api/leaves/[id]/route');
+
+function appRow(overrides = {}) {
+	return {
+		id: 5,
+		user_id: 2,
+		leave_type_id: 1,
+		start_date: '2026-08-25',
+		end_date: '2026-08-26',
+		half_day: 0,
+		duration_days: 2,
+		status: 'pending',
+		reviewed_by: null,
+		reviewed_at: null,
+		review_notes: null,
+		written_attendance: null,
+		code: 'CL',
+		is_paid: 1,
+		requires_balance: 1,
+		default_annual_quota: 12,
+		employee_id: 3,
+		...overrides,
+	};
+}
+
+describe('PATCH /api/leaves/[id]', () => {
+	beforeEach(() => {
+		mockExecute.mockReset();
+		mockEnsurePermission.mockReset();
+		mockEnsurePermission.mockResolvedValue({
+			authorized: true,
+			user: { id: 1, is_super_admin: true },
+		});
+	});
+
+	it('rejects a rejection without review_notes with 400', async () => {
+		const req = new Request('http://localhost/api/leaves/5', {
+			method: 'PATCH',
+			body: JSON.stringify({ status: 'rejected' }),
+		});
+		const res = await PATCH(req, { params: Promise.resolve({ id: '5' }) });
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toMatch(/review_notes is required/i);
+		expect(mockExecute).not.toHaveBeenCalled();
+	});
+
+	it('approving writes attendance rows and the balance ledger inside the audit JSON', async () => {
+		mockExecute.mockResolvedValueOnce([[appRow()]]); // loadApplication
+		mockExecute.mockResolvedValue([[]]); // existing attendance / holidays / inserts / update
+
+		const req = new Request('http://localhost/api/leaves/5', {
+			method: 'PATCH',
+			body: JSON.stringify({ status: 'approved', review_notes: 'Enjoy' }),
+		});
+		const res = await PATCH(req, { params: Promise.resolve({ id: '5' }) });
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.success).toBe(true);
+		expect(body.data.status).toBe('approved');
+
+		const sqls = mockExecute.mock.calls.map(([sql]) => String(sql));
+		const attendanceWrites = sqls.filter((sql) =>
+			sql.includes('INSERT INTO employee_attendance')
+		);
+		expect(attendanceWrites).toHaveLength(2); // two working days
+
+		const ledgerWrite = sqls.find((sql) =>
+			sql.includes('INSERT INTO employee_leaves')
+		);
+		expect(ledgerWrite).toBeTruthy();
+
+		const updateCall = mockExecute.mock.calls.find(([sql]) =>
+			String(sql).includes('UPDATE leave_applications')
+		);
+		const audit = JSON.parse(updateCall[1][3]);
+		expect(audit.attendance).toHaveLength(2);
+		expect(audit.balances).toEqual([{ leave_type_id: 1, year: 2026, days: 2 }]);
+	});
+
+	it('returns 409 when the application is already in the requested status', async () => {
+		mockExecute.mockResolvedValueOnce([[appRow({ status: 'approved' })]]);
+		const req = new Request('http://localhost/api/leaves/5', {
+			method: 'PATCH',
+			body: JSON.stringify({ status: 'approved' }),
+		});
+		const res = await PATCH(req, { params: Promise.resolve({ id: '5' }) });
+		expect(res.status).toBe(409);
+	});
+
+	it('rejecting an approved application reverts balances and attendance', async () => {
+		mockExecute.mockResolvedValueOnce([
+			[
+				appRow({
+					status: 'approved',
+					written_attendance: JSON.stringify({
+						attendance: [
+							{ date: '2026-08-25', prev_status: null },
+							{ date: '2026-08-26', prev_status: 'A' },
+						],
+						balances: [{ leave_type_id: 1, year: 2026, days: 2 }],
+					}),
+				}),
+			],
+		]);
+		mockExecute.mockResolvedValue([[]]);
+
+		const req = new Request('http://localhost/api/leaves/5', {
+			method: 'PATCH',
+			body: JSON.stringify({ status: 'rejected', review_notes: 'Peak season' }),
+		});
+		const res = await PATCH(req, { params: Promise.resolve({ id: '5' }) });
+
+		expect(res.status).toBe(200);
+		const sqls = mockExecute.mock.calls.map(([sql]) => String(sql));
+		expect(
+			sqls.filter((sql) => sql.includes('DELETE FROM employee_attendance'))
+		).toHaveLength(1);
+		expect(
+			sqls.filter((sql) => sql.includes('UPDATE employee_attendance'))
+		).toHaveLength(1);
+		expect(
+			sqls.filter((sql) => sql.includes('used_leaves = GREATEST'))
+		).toHaveLength(1);
+	});
+
+	it('passes through 403 when approve permission is missing', async () => {
+		mockEnsurePermission.mockResolvedValue({
+			authorized: false,
+			response: new Response('Forbidden', { status: 403 }),
+		});
+		const req = new Request('http://localhost/api/leaves/5', {
+			method: 'PATCH',
+			body: JSON.stringify({ status: 'approved' }),
+		});
+		const res = await PATCH(req, { params: Promise.resolve({ id: '5' }) });
+		expect(res.status).toBe(403);
+		expect(mockExecute).not.toHaveBeenCalled();
+	});
+});
+
+describe('DELETE /api/leaves/[id]', () => {
+	beforeEach(() => {
+		mockExecute.mockReset();
+		mockGetCurrentUser.mockReset();
+		mockGetCurrentUser.mockResolvedValue({ id: 7 });
+	});
+
+	it('lets the owner withdraw their own pending application (soft delete)', async () => {
+		mockExecute.mockResolvedValueOnce([[appRow({ user_id: 7 })]]); // loadApplication
+		mockExecute.mockResolvedValue([[]]);
+
+		const req = new Request('http://localhost/api/leaves/5', {
+			method: 'DELETE',
+		});
+		const res = await DELETE(req, { params: Promise.resolve({ id: '5' }) });
+		expect(res.status).toBe(200);
+
+		const deleteSql = mockExecute.mock.calls.find(([sql]) =>
+			String(sql).includes('SET isDelete = 1')
+		);
+		expect(deleteSql).toBeTruthy();
+	});
+
+	it('blocks non-owner users without leaves:delete from withdrawing', async () => {
+		mockExecute.mockResolvedValueOnce([[appRow({ user_id: 2 })]]);
+		const req = new Request('http://localhost/api/leaves/5', {
+			method: 'DELETE',
+		});
+		const res = await DELETE(req, { params: Promise.resolve({ id: '5' }) });
+		expect(res.status).toBe(403);
+	});
+});

--- a/src/__tests__/api/leaves/route.test.ts
+++ b/src/__tests__/api/leaves/route.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock DB + auth BEFORE dynamic imports (Vitest hoists mocks)
+const mockExecute = vi.fn();
+const mockConn = { execute: mockExecute, release: vi.fn() };
+
+vi.mock('@/utils/database', () => ({
+	dbConnect: vi.fn().mockResolvedValue(mockConn),
+	withTransaction: vi.fn((fn) => fn(mockConn)),
+}));
+
+const mockEnsurePermission = vi
+	.fn()
+	.mockResolvedValue({ authorized: true, user: { id: 1 } });
+vi.mock('@/utils/api-permissions', () => ({
+	ensurePermission: (...args) => mockEnsurePermission(...args),
+	RESOURCES: { LEAVES: 'leaves' },
+	PERMISSIONS: {
+		READ: 'read',
+		CREATE: 'create',
+		UPDATE: 'update',
+		DELETE: 'delete',
+		APPROVE: 'approve',
+	},
+}));
+
+vi.mock('@/utils/activity-logger', () => ({
+	logActivity: vi.fn(),
+}));
+
+const { GET, POST } = await import('@/app/api/leaves/route');
+
+describe('GET /api/leaves', () => {
+	beforeEach(() => {
+		mockExecute.mockReset();
+		mockEnsurePermission.mockReset();
+		mockEnsurePermission.mockResolvedValue({
+			authorized: true,
+			user: { id: 1 },
+		});
+	});
+
+	it('scopes the list to the requester when they cannot approve', async () => {
+		mockExecute.mockResolvedValue([
+			[{ id: 4, status: 'pending', applicant_name: 'Self' }],
+		]);
+		const req = new Request('http://localhost/api/leaves');
+		const res = await GET(req);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.success).toBe(true);
+		expect(body.data).toHaveLength(1);
+		const [sql] = mockExecute.mock.calls[0];
+		expect(sql).toContain('la.user_id = ?');
+		expect(sql).toContain(
+			'WHERE isDelete = 0'.replace('isDelete = 0', 'la.isDelete = 0')
+		);
+	});
+
+	it('returns all applications for approvers', async () => {
+		mockEnsurePermission.mockResolvedValue({
+			authorized: true,
+			user: { id: 1, is_super_admin: true },
+		});
+		mockExecute.mockResolvedValue([[]]);
+		const req = new Request('http://localhost/api/leaves');
+		const res = await GET(req);
+		expect(res.status).toBe(200);
+		const [sql, params] = mockExecute.mock.calls[0];
+		expect(sql).not.toContain('la.user_id = ?');
+		expect(sql).toContain('LIMIT 50 OFFSET 0');
+		// limit/offset are interpolated, NOT bound — extra bindings make MariaDB
+		// silently return an empty result set
+		expect(params).toEqual([]);
+	});
+
+	it('passes through 403 when read permission is missing', async () => {
+		mockEnsurePermission.mockResolvedValue({
+			authorized: false,
+			response: new Response('Forbidden', { status: 403 }),
+		});
+		const req = new Request('http://localhost/api/leaves');
+		const res = await GET(req);
+		expect(res.status).toBe(403);
+		expect(mockExecute).not.toHaveBeenCalled();
+	});
+});
+
+describe('POST /api/leaves', () => {
+	beforeEach(() => {
+		mockExecute.mockReset();
+		mockEnsurePermission.mockReset();
+		mockEnsurePermission.mockResolvedValue({
+			authorized: true,
+			user: { id: 1 },
+		});
+	});
+
+	const validBody = {
+		leave_type_id: 2,
+		start_date: '2026-08-25',
+		end_date: '2026-08-26',
+		reason: 'Family function',
+	};
+
+	it('rejects invalid dates with 400 and never touches the DB', async () => {
+		const req = new Request('http://localhost/api/leaves', {
+			method: 'POST',
+			body: JSON.stringify({ ...validBody, start_date: '25-08-2026' }),
+		});
+		const res = await POST(req);
+		expect(res.status).toBe(400);
+		expect(mockExecute).not.toHaveBeenCalled();
+	});
+
+	it('rejects end_date before start_date with 400', async () => {
+		const req = new Request('http://localhost/api/leaves', {
+			method: 'POST',
+			body: JSON.stringify({
+				...validBody,
+				end_date: '2026-08-24',
+			}),
+		});
+		const res = await POST(req);
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toMatch(/on or after start_date/i);
+	});
+
+	it('rejects a half-day spanning multiple dates with 400', async () => {
+		const req = new Request('http://localhost/api/leaves', {
+			method: 'POST',
+			body: JSON.stringify({ ...validBody, half_day: true }),
+		});
+		const res = await POST(req);
+		expect(res.status).toBe(400);
+	});
+
+	it('rejects overlapping pending/approved applications with 409', async () => {
+		mockExecute.mockResolvedValueOnce([[{ id: 1, name: 'Casual Leave' }]]);
+		mockExecute.mockResolvedValueOnce([[{ id: 99 }]]);
+		const req = new Request('http://localhost/api/leaves', {
+			method: 'POST',
+			body: JSON.stringify(validBody),
+		});
+		const res = await POST(req);
+		expect(res.status).toBe(409);
+	});
+
+	it('inserts a pending application with server-computed duration', async () => {
+		mockExecute.mockResolvedValueOnce([[{ id: 1, name: 'Casual Leave' }]]);
+		mockExecute.mockResolvedValueOnce([[]]); // overlap check
+		mockExecute.mockResolvedValueOnce([{ insertId: 9 }]);
+		const req = new Request('http://localhost/api/leaves', {
+			method: 'POST',
+			body: JSON.stringify(validBody),
+		});
+		const res = await POST(req);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.success).toBe(true);
+		expect(body.data.duration_days).toBe(2);
+		expect(body.data.status).toBe('pending');
+
+		const insertCall = mockExecute.mock.calls.find(([sql]) =>
+			String(sql).includes('INSERT INTO leave_applications')
+		);
+		expect(insertCall).toBeTruthy();
+		expect(String(insertCall[0])).toContain("'pending'");
+		expect(insertCall[1][5]).toBe(2); // duration_days
+		expect(insertCall[1][6]).toBe('Family function');
+	});
+
+	it('computes 0.5 days for a single-date half-day application', async () => {
+		mockExecute.mockResolvedValueOnce([[{ id: 1, name: 'Casual Leave' }]]);
+		mockExecute.mockResolvedValueOnce([[]]);
+		mockExecute.mockResolvedValueOnce([{ insertId: 10 }]);
+		const req = new Request('http://localhost/api/leaves', {
+			method: 'POST',
+			body: JSON.stringify({
+				...validBody,
+				end_date: '2026-08-25',
+				half_day: true,
+			}),
+		});
+		const res = await POST(req);
+		const body = await res.json();
+		expect(res.status).toBe(200);
+		expect(body.data.duration_days).toBe(0.5);
+	});
+});

--- a/src/__tests__/lib/leave-display.test.ts
+++ b/src/__tests__/lib/leave-display.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { pickRecentDecision, DECISION_WINDOW_DAYS } from '@/lib/leave-display';
+
+const NOW = new Date('2026-08-25T10:00:00Z');
+const daysAgo = (n) => new Date(NOW.getTime() - n * 86_400_000).toISOString();
+
+describe('pickRecentDecision', () => {
+	it('returns null when there are no applications', () => {
+		expect(pickRecentDecision([], NOW)).toBeNull();
+		expect(pickRecentDecision(undefined, NOW)).toBeNull();
+	});
+
+	it('returns null when nothing has been reviewed yet', () => {
+		expect(
+			pickRecentDecision([{ id: 1, status: 'pending', reviewed_at: null }], NOW)
+		).toBeNull();
+	});
+
+	it('surfaces a recent approval', () => {
+		const decision = pickRecentDecision(
+			[{ id: 7, status: 'approved', reviewed_at: daysAgo(1) }],
+			NOW
+		);
+		expect(decision).toEqual({
+			id: 7,
+			kind: 'approved',
+			reviewedAt: daysAgo(1),
+		});
+	});
+
+	it('surfaces a recent rejection the same way', () => {
+		const decision = pickRecentDecision(
+			[{ id: 8, status: 'rejected', reviewed_at: daysAgo(2) }],
+			NOW
+		);
+		expect(decision?.kind).toBe('rejected');
+	});
+
+	it('ignores decisions older than the window', () => {
+		expect(
+			pickRecentDecision(
+				[
+					{
+						id: 9,
+						status: 'approved',
+						reviewed_at: daysAgo(DECISION_WINDOW_DAYS + 1),
+					},
+				],
+				NOW
+			)
+		).toBeNull();
+	});
+
+	it('keeps a decision exactly at the window boundary', () => {
+		const decision = pickRecentDecision(
+			[
+				{
+					id: 10,
+					status: 'approved',
+					reviewed_at: daysAgo(DECISION_WINDOW_DAYS),
+				},
+			],
+			NOW
+		);
+		expect(decision?.id).toBe(10);
+	});
+
+	it('prefers the most recent review when several qualify', () => {
+		const decision = pickRecentDecision(
+			[
+				{ id: 11, status: 'approved', reviewed_at: daysAgo(3) },
+				{ id: 12, status: 'rejected', reviewed_at: daysAgo(1) },
+			],
+			NOW
+		);
+		expect(decision).toEqual({
+			id: 12,
+			kind: 'rejected',
+			reviewedAt: daysAgo(1),
+		});
+	});
+
+	it('skips applications with missing or invalid reviewed_at', () => {
+		expect(
+			pickRecentDecision(
+				[
+					{ id: 13, status: 'approved' },
+					{ id: 14, status: 'rejected', reviewed_at: 'not-a-date' },
+				],
+				NOW
+			)
+		).toBeNull();
+	});
+});

--- a/src/app/api/leaves/[id]/route.ts
+++ b/src/app/api/leaves/[id]/route.ts
@@ -1,0 +1,257 @@
+import { NextResponse } from 'next/server';
+import { dbConnect, withTransaction } from '@/utils/database';
+import { ensurePermission, getCurrentUser } from '@/utils/api-permissions';
+import { RESOURCES, PERMISSIONS, hasPermission } from '@/utils/rbac';
+import { logActivity } from '@/utils/activity-logger';
+import { applyApprovedLeave, revertApprovedLeave } from '@/utils/leave-helpers';
+
+const VALID_STATUSES = ['pending', 'approved', 'rejected'];
+
+/**
+ * Loads an application joined with everything the side-effect helpers need.
+ */
+async function loadApplication(
+	db: Awaited<ReturnType<typeof dbConnect>>,
+	id: number
+) {
+	const [rows] = await db.execute(
+		`SELECT la.id, la.user_id, la.leave_type_id, la.start_date, la.end_date,
+              la.half_day, la.duration_days, la.status, la.reviewed_by,
+              la.reviewed_at, la.review_notes, la.written_attendance,
+              lt.code, lt.is_paid, lt.requires_balance, lt.default_annual_quota,
+              u.employee_id
+       FROM leave_applications la
+       JOIN leave_types lt ON la.leave_type_id = lt.id
+       JOIN users u ON la.user_id = u.id
+       WHERE la.id = ? AND la.isDelete = 0`,
+		[id]
+	);
+	return (rows as Array<Record<string, unknown>>)[0] ?? null;
+}
+
+/**
+ * PATCH /api/leaves/[id]
+ *
+ * Review workflow — requires leaves:approve.
+ * Body: { status: 'approved' | 'rejected' | 'pending', review_notes? }
+ *
+ * Approving writes attendance rows + balance ledger inside one transaction;
+ * moving an approved request back to rejected/pending reverses them using the
+ * written_attendance audit payload. Rejecting requires review_notes.
+ */
+export async function PATCH(
+	request: Request,
+	{ params }: { params: Promise<{ id: string }> }
+) {
+	const authResult = await ensurePermission(
+		request,
+		RESOURCES.LEAVES,
+		PERMISSIONS.APPROVE
+	);
+	if (authResult instanceof Response) return authResult;
+	if (!authResult.authorized) return authResult.response;
+
+	const reviewer = authResult.user;
+	const { id: rawId } = await params;
+	const id = Number(rawId);
+	if (!Number.isInteger(id) || id <= 0) {
+		return NextResponse.json(
+			{ success: false, error: 'Invalid application id' },
+			{ status: 400 }
+		);
+	}
+
+	let body: { status?: string; review_notes?: string };
+	try {
+		body = await request.json();
+	} catch (_) {
+		return NextResponse.json(
+			{ success: false, error: 'Invalid JSON body' },
+			{ status: 400 }
+		);
+	}
+
+	const nextStatus = String(body?.status ?? '');
+	if (!VALID_STATUSES.includes(nextStatus)) {
+		return NextResponse.json(
+			{
+				success: false,
+				error: "status must be 'approved', 'rejected' or 'pending'",
+			},
+			{ status: 400 }
+		);
+	}
+	const reviewNotes =
+		body?.review_notes === undefined || body?.review_notes === null
+			? null
+			: String(body.review_notes).trim();
+
+	if (nextStatus === 'rejected' && !reviewNotes) {
+		return NextResponse.json(
+			{
+				success: false,
+				error: 'review_notes is required when rejecting a leave',
+			},
+			{ status: 400 }
+		);
+	}
+
+	try {
+		const updated = await withTransaction(async (db) => {
+			const app = await loadApplication(db, id);
+			if (!app) return null;
+			if (app.status === nextStatus) {
+				throw new Error(`Leave application is already ${nextStatus}`);
+			}
+
+			let auditJson: string | null = null;
+
+			// Leaving the approved state → undo attendance + balances first.
+			if (app.status === 'approved') {
+				await revertApprovedLeave(db, app as never);
+			}
+			// Entering the approved state → apply side-effects and record audit.
+			if (nextStatus === 'approved') {
+				const audit = await applyApprovedLeave(db, app as never, reviewer.id);
+				auditJson = JSON.stringify(audit);
+			}
+
+			await db.execute(
+				`UPDATE leave_applications
+         SET status = ?, review_notes = ?, reviewed_by = ?, reviewed_at = NOW(),
+             written_attendance = ?
+         WHERE id = ? AND isDelete = 0`,
+				[nextStatus, reviewNotes, reviewer.id, auditJson, id]
+			);
+
+			return { id, status: nextStatus, review_notes: reviewNotes };
+		});
+
+		if (!updated) {
+			return NextResponse.json(
+				{ success: false, error: 'Leave application not found' },
+				{ status: 404 }
+			);
+		}
+
+		logActivity({
+			userId: reviewer.id,
+			actionType:
+				nextStatus === 'approved'
+					? 'approve'
+					: nextStatus === 'rejected'
+						? 'reject'
+						: 'reopen',
+			resourceType: 'leave_applications',
+			resourceId: id,
+			description: `Leave application #${id} ${nextStatus}${reviewNotes ? `: ${reviewNotes}` : ''}`,
+			details: null,
+			request,
+			status: 'success',
+		});
+
+		return NextResponse.json({ success: true, data: updated });
+	} catch (error) {
+		const message =
+			error instanceof Error ? error.message : 'Failed to update leave';
+		const notFound = message.includes('not found');
+		const conflict = message.startsWith('Leave application is already');
+		console.error('Error reviewing leave application:', error);
+		return NextResponse.json(
+			{ success: false, error: message },
+			{ status: conflict ? 409 : notFound ? 404 : 500 }
+		);
+	}
+}
+
+/**
+ * DELETE /api/leaves/[id]
+ *
+ * - Owner may withdraw their own pending application.
+ * - Users with leaves:delete may soft-delete any application; deleting an
+ *   approved one also reverses its attendance/balance side-effects.
+ */
+export async function DELETE(
+	request: Request,
+	{ params }: { params: Promise<{ id: string }> }
+) {
+	const user = await getCurrentUser(request);
+	if (!user) {
+		return NextResponse.json(
+			{ success: false, error: 'Unauthorized' },
+			{ status: 401 }
+		);
+	}
+
+	const { id: rawId } = await params;
+	const id = Number(rawId);
+	if (!Number.isInteger(id) || id <= 0) {
+		return NextResponse.json(
+			{ success: false, error: 'Invalid application id' },
+			{ status: 400 }
+		);
+	}
+
+	try {
+		const result = await withTransaction(async (db) => {
+			const app = await loadApplication(db, id);
+			if (!app) return { ok: false as const, status: 404 };
+
+			const isOwner = Number(app.user_id) === Number(user.id);
+			const canDeleteAny =
+				user.is_super_admin ||
+				hasPermission(user, RESOURCES.LEAVES, PERMISSIONS.DELETE);
+
+			const ownerWithdraw = isOwner && app.status === 'pending';
+			if (!canDeleteAny && !ownerWithdraw) {
+				return { ok: false as const, status: 403 };
+			}
+
+			if (app.status === 'approved') {
+				await revertApprovedLeave(db, app as never);
+			}
+
+			await db.execute(
+				`UPDATE leave_applications SET isDelete = 1 WHERE id = ?`,
+				[id]
+			);
+			return { ok: true as const };
+		});
+
+		if (!result.ok) {
+			const errors: Record<number, string> = {
+				404: 'Leave application not found',
+				403: 'You can only withdraw your own pending applications',
+			};
+			return NextResponse.json(
+				{ success: false, error: errors[result.status] },
+				{ status: result.status }
+			);
+		}
+
+		logActivity({
+			userId: user.id,
+			actionType: 'delete',
+			resourceType: 'leave_applications',
+			resourceId: id,
+			description: `Leave application #${id} withdrawn/deleted`,
+			details: null,
+			request,
+			status: 'success',
+		});
+
+		return NextResponse.json({ success: true });
+	} catch (error) {
+		console.error('Error deleting leave application:', error);
+		return NextResponse.json(
+			{
+				success: false,
+				error:
+					error instanceof Error
+						? error.message
+						: 'Failed to delete leave application',
+			},
+			{ status: 500 }
+		);
+	}
+}

--- a/src/app/api/leaves/balances/route.ts
+++ b/src/app/api/leaves/balances/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from 'next/server';
+import { dbConnect } from '@/utils/database';
+import {
+	ensurePermission,
+	RESOURCES,
+	PERMISSIONS,
+} from '@/utils/api-permissions';
+
+/**
+ * GET /api/leaves/balances
+ *
+ * Leave balance summary for the signed-in user for a given year
+ * (query param `year`, defaults to the current year). Returns the active
+ * leave types alongside per-type and aggregate balances.
+ */
+export async function GET(request: Request) {
+	const authResult = await ensurePermission(
+		request,
+		RESOURCES.LEAVES,
+		PERMISSIONS.READ
+	);
+	if (authResult instanceof Response) return authResult;
+	if (!authResult.authorized) return authResult.response;
+
+	const user = authResult.user;
+	const { searchParams } = new URL(request.url);
+	const rawYear = Number(searchParams.get('year'));
+	const year =
+		Number.isInteger(rawYear) && rawYear >= 2000 && rawYear <= 2100
+			? rawYear
+			: new Date().getFullYear();
+
+	let db;
+	try {
+		db = await dbConnect();
+
+		const [userRows] = await db.execute(
+			`SELECT employee_id FROM users WHERE id = ? AND isDelete = 0`,
+			[user.id]
+		);
+		const employeeId = userRows[0]?.employee_id ?? null;
+
+		const [types] = await db.execute(
+			`SELECT id, name, code, is_paid, default_annual_quota AS quota,
+              requires_balance
+       FROM leave_types WHERE isDelete = 0 ORDER BY id ASC`
+		);
+
+		const usedByType = new Map<number, number>();
+		const totalByType = new Map<number, number>();
+
+		if (employeeId) {
+			const [balanceRows] = await db.execute(
+				`SELECT leave_type_id, total_leaves, used_leaves
+         FROM employee_leaves WHERE employee_id = ? AND year = ?`,
+				[employeeId, year]
+			);
+			for (const row of balanceRows) {
+				totalByType.set(Number(row.leave_type_id), Number(row.total_leaves));
+				usedByType.set(Number(row.leave_type_id), Number(row.used_leaves));
+			}
+		}
+
+		const withBalances = (types as Array<Record<string, unknown>>).map(
+			(type) => {
+				const typeId = Number(type.id);
+				const requiresBalance = Number(type.requires_balance) === 1;
+				const quota = Number(type.quota ?? 0);
+				const total = requiresBalance ? (totalByType.get(typeId) ?? quota) : 0;
+				const used = requiresBalance ? (usedByType.get(typeId) ?? 0) : 0;
+				return {
+					id: typeId,
+					name: type.name,
+					code: type.code,
+					is_paid: Number(type.is_paid) === 1,
+					requires_balance: requiresBalance,
+					quota,
+					total,
+					used,
+					remaining: Math.max(0, total - used),
+				};
+			}
+		);
+
+		const totals = withBalances.reduce(
+			(acc, item) => {
+				acc.total += item.total;
+				acc.used += item.used;
+				return acc;
+			},
+			{ total: 0, used: 0 }
+		);
+
+		return NextResponse.json({
+			success: true,
+			data: {
+				year,
+				types: withBalances,
+				totals: {
+					total: totals.total,
+					used: totals.used,
+					balance: Math.max(0, totals.total - totals.used),
+				},
+			},
+		});
+	} catch (error) {
+		console.error('Error fetching leave balances:', error);
+		return NextResponse.json(
+			{
+				success: false,
+				error:
+					error instanceof Error
+						? error.message
+						: 'Failed to fetch leave balances',
+			},
+			{ status: 500 }
+		);
+	} finally {
+		if (db) await db.release();
+	}
+}

--- a/src/app/api/leaves/route.ts
+++ b/src/app/api/leaves/route.ts
@@ -1,0 +1,280 @@
+import { NextResponse } from 'next/server';
+import { dbConnect } from '@/utils/database';
+import {
+	ensurePermission,
+	RESOURCES,
+	PERMISSIONS,
+} from '@/utils/api-permissions';
+import { hasPermission } from '@/utils/rbac';
+import { logActivity } from '@/utils/activity-logger';
+import {
+	computeDurationDays,
+	parseDateInput,
+	MAX_LEAVE_RANGE_DAYS,
+} from '@/utils/leave-helpers';
+
+const VALID_STATUSES = ['pending', 'approved', 'rejected'];
+
+/**
+ * GET /api/leaves
+ *
+ * Lists leave applications. Users without leaves:approve only ever see their
+ * own applications; approvers see everything and may filter by user_id.
+ * Query params: status, user_id, from, to, scope ('mine'), limit.
+ */
+export async function GET(request: Request) {
+	const authResult = await ensurePermission(
+		request,
+		RESOURCES.LEAVES,
+		PERMISSIONS.READ
+	);
+	if (authResult instanceof Response) return authResult;
+	if (!authResult.authorized) return authResult.response;
+
+	const user = authResult.user;
+	const canReviewAll =
+		user.is_super_admin ||
+		hasPermission(user, RESOURCES.LEAVES, PERMISSIONS.APPROVE);
+
+	const { searchParams } = new URL(request.url);
+	const mineOnly = !canReviewAll || searchParams.get('scope') === 'mine';
+
+	let db;
+	try {
+		db = await dbConnect();
+
+		const conditions: string[] = ['la.isDelete = 0'];
+		const params: Array<string | number> = [];
+
+		if (mineOnly) {
+			conditions.push('la.user_id = ?');
+			params.push(user.id);
+		} else {
+			const userId = Number(searchParams.get('user_id'));
+			if (Number.isInteger(userId) && userId > 0) {
+				conditions.push('la.user_id = ?');
+				params.push(userId);
+			}
+		}
+
+		const status = searchParams.get('status');
+		if (status && VALID_STATUSES.includes(status)) {
+			conditions.push('la.status = ?');
+			params.push(status);
+		}
+
+		const from = parseDateInput(searchParams.get('from') ?? '');
+		if (from) {
+			conditions.push('la.end_date >= ?');
+			params.push(from);
+		}
+
+		const to = parseDateInput(searchParams.get('to') ?? '');
+		if (to) {
+			conditions.push('la.start_date <= ?');
+			params.push(to);
+		}
+
+		const rawLimit = Number(searchParams.get('limit')) || 50;
+		const limit = Math.min(Math.max(Math.trunc(rawLimit), 1), 200);
+		const rawPage = Number(searchParams.get('page')) || 1;
+		const page = Math.max(Math.trunc(rawPage), 1);
+		const offset = (page - 1) * limit;
+		// NOTE: limit/offset are clamped integers interpolated into SQL — do NOT
+		// also push them into `params`. MariaDB silently returns an empty result
+		// set when a prepared statement receives more bindings than placeholders.
+		const [rows] = await db.execute(
+			`SELECT la.id, la.user_id, u.full_name AS applicant_name,
+              la.leave_type_id, lt.name AS leave_type_name, lt.code AS leave_type_code,
+              lt.is_paid, la.start_date, la.end_date, la.half_day, la.duration_days,
+              la.reason, la.status, la.reviewed_by, r.full_name AS reviewer_name,
+              la.reviewed_at, la.review_notes, la.created_at
+       FROM leave_applications la
+       JOIN users u ON la.user_id = u.id
+       JOIN leave_types lt ON la.leave_type_id = lt.id
+       LEFT JOIN users r ON la.reviewed_by = r.id
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY la.created_at DESC, la.id DESC
+       LIMIT ${limit} OFFSET ${offset}`,
+			params
+		);
+
+		return NextResponse.json({ success: true, data: rows });
+	} catch (error) {
+		console.error('Error fetching leave applications:', error);
+		return NextResponse.json(
+			{
+				success: false,
+				error:
+					error instanceof Error
+						? error.message
+						: 'Failed to fetch leave applications',
+			},
+			{ status: 500 }
+		);
+	} finally {
+		if (db) await db.release();
+	}
+}
+
+/**
+ * POST /api/leaves
+ *
+ * Creates a pending leave application. duration_days is always computed
+ * server-side; overlapping pending/approved requests are rejected.
+ * Body: { leave_type_id, start_date, end_date, half_day?, reason }
+ */
+export async function POST(request: Request) {
+	const authResult = await ensurePermission(
+		request,
+		RESOURCES.LEAVES,
+		PERMISSIONS.CREATE
+	);
+	if (authResult instanceof Response) return authResult;
+	if (!authResult.authorized) return authResult.response;
+
+	let db;
+	try {
+		const body = await request.json();
+		const leaveTypeId = Number(body?.leave_type_id);
+		const startDate = parseDateInput(body?.start_date);
+		const endDate = parseDateInput(body?.end_date);
+		const halfDay = Boolean(body?.half_day);
+		const reason = String(body?.reason ?? '').trim();
+
+		if (!Number.isInteger(leaveTypeId) || leaveTypeId <= 0) {
+			return NextResponse.json(
+				{ success: false, error: 'A valid leave type is required' },
+				{ status: 400 }
+			);
+		}
+		if (!startDate || !endDate) {
+			return NextResponse.json(
+				{
+					success: false,
+					error: 'start_date and end_date are required as YYYY-MM-DD',
+				},
+				{ status: 400 }
+			);
+		}
+		if (!reason) {
+			return NextResponse.json(
+				{ success: false, error: 'Reason is required' },
+				{ status: 400 }
+			);
+		}
+
+		const durationDays = computeDurationDays(startDate, endDate, halfDay);
+		if (durationDays <= 0) {
+			return NextResponse.json(
+				{ success: false, error: 'end_date must be on or after start_date' },
+				{ status: 400 }
+			);
+		}
+		if (durationDays > MAX_LEAVE_RANGE_DAYS) {
+			return NextResponse.json(
+				{
+					success: false,
+					error: `Leave range cannot exceed ${MAX_LEAVE_RANGE_DAYS} days`,
+				},
+				{ status: 400 }
+			);
+		}
+		if (halfDay && startDate !== endDate) {
+			return NextResponse.json(
+				{
+					success: false,
+					error: 'Half-day applies only to a single-date leave',
+				},
+				{ status: 400 }
+			);
+		}
+
+		db = await dbConnect();
+
+		const [typeRows] = await db.execute(
+			`SELECT id, name FROM leave_types WHERE id = ? AND isDelete = 0`,
+			[leaveTypeId]
+		);
+		if (typeRows.length === 0) {
+			return NextResponse.json(
+				{ success: false, error: 'Leave type not found' },
+				{ status: 404 }
+			);
+		}
+
+		const [overlaps] = await db.execute(
+			`SELECT id FROM leave_applications
+       WHERE user_id = ? AND isDelete = 0
+         AND status IN ('pending', 'approved')
+         AND NOT (end_date < ? OR start_date > ?)
+       LIMIT 1`,
+			[authResult.user.id, startDate, endDate]
+		);
+		if (overlaps.length > 0) {
+			return NextResponse.json(
+				{
+					success: false,
+					error:
+						'You already have a pending or approved leave overlapping these dates',
+				},
+				{ status: 409 }
+			);
+		}
+
+		const [result] = await db.execute(
+			`INSERT INTO leave_applications
+       (user_id, leave_type_id, start_date, end_date, half_day, duration_days, reason, status)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'pending')`,
+			[
+				authResult.user.id,
+				leaveTypeId,
+				startDate,
+				endDate,
+				halfDay ? 1 : 0,
+				durationDays,
+				reason,
+			]
+		);
+		const insertId = result.insertId;
+
+		logActivity({
+			userId: authResult.user.id,
+			actionType: 'create',
+			resourceType: 'leave_applications',
+			resourceId: insertId,
+			description: `Applied for ${typeRows[0].name} (${durationDays} day(s), ${startDate} → ${endDate})`,
+			details: null,
+			request,
+			status: 'success',
+		});
+
+		return NextResponse.json({
+			success: true,
+			data: {
+				id: insertId,
+				leave_type_id: leaveTypeId,
+				start_date: startDate,
+				end_date: endDate,
+				half_day: halfDay,
+				duration_days: durationDays,
+				reason,
+				status: 'pending',
+			},
+		});
+	} catch (error) {
+		console.error('Error creating leave application:', error);
+		return NextResponse.json(
+			{
+				success: false,
+				error:
+					error instanceof Error
+						? error.message
+						: 'Failed to create leave application',
+			},
+			{ status: 500 }
+		);
+	} finally {
+		if (db) await db.release();
+	}
+}

--- a/src/app/dashboard/user-dashboard.jsx
+++ b/src/app/dashboard/user-dashboard.jsx
@@ -21,12 +21,14 @@ import {
 	ArrowRightStartOnRectangleIcon,
 	CalendarDaysIcon,
 	CalendarIcon,
+	ArrowRightIcon,
 	FireIcon,
 	ExclamationTriangleIcon,
 	ComputerDesktopIcon,
 	ExclamationCircleIcon,
 	ArrowLeftIcon,
 } from '@heroicons/react/24/outline';
+import LeaveLoginToast from '@/components/LeaveLoginToast';
 import { useIdleMonitor } from '@/hooks/useIdleMonitor';
 
 // ── Lazy-load heavy components (code-split, only fetched when needed) ──
@@ -615,6 +617,9 @@ export default function UserDashboard({ verifiedUser, backTo }) {
 		<div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
 			<Navbar />
 
+			{/* One-time toast when a recent leave request was approved/rejected */}
+			<LeaveLoginToast />
+
 			{/* Activity Reminder Modal */}
 			{showActivityReminder && pendingActivities.length > 0 && (
 				<div
@@ -1038,8 +1043,14 @@ export default function UserDashboard({ verifiedUser, backTo }) {
 											)}
 										</div>
 									</div>
-									{/* Leave Days */}
-									<div className="group relative rounded-xl border border-amber-200 bg-gradient-to-br from-amber-50 via-white to-yellow-50 p-3 hover:shadow-lg hover:border-amber-400 hover:-translate-y-0.5 transition-all duration-300 overflow-hidden">
+									{/* Leave Days — click to open full Leave Management */}
+									<button
+										type="button"
+										onClick={() => router.push('/user/leaves')}
+										aria-label="Open leave management — view balances and apply for leave"
+										title="View balances and apply for leave"
+										className="group relative rounded-xl text-left border border-amber-200 bg-gradient-to-br from-amber-50 via-white to-yellow-50 p-3 cursor-pointer hover:shadow-lg hover:border-amber-400 hover:-translate-y-0.5 active:scale-[0.98] transition-all duration-300 overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#64126D]/50 focus-visible:ring-offset-1"
+									>
 										<div className="absolute top-0 right-0 w-20 h-20 bg-amber-200/30 rounded-full -translate-x-4 -translate-y-4 blur-lg group-hover:scale-125 transition-transform duration-500" />
 										<div className="relative">
 											<div className="flex items-center justify-between mb-2">
@@ -1064,8 +1075,12 @@ export default function UserDashboard({ verifiedUser, backTo }) {
 												<span className="w-1.5 h-1.5 rounded-full bg-amber-500 inline-block" />{' '}
 												{attendance.leaves.balance} remaining
 											</p>
+											<p className="mt-1.5 pt-1.5 border-t border-amber-200/60 -mx-px flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider text-[#64126D] transition-colors duration-150 group-hover:text-[#4a0d52]">
+												View &amp; apply
+												<ArrowRightIcon className="h-2.5 w-2.5 transition-transform duration-150 group-hover:translate-x-0.5 motion-reduce:transition-none" />
+											</p>
 										</div>
-									</div>
+									</button>
 									{/* Overtime */}
 									<div className="group relative rounded-xl border border-orange-200 bg-gradient-to-br from-orange-50 via-white to-amber-50 p-3 hover:shadow-lg hover:border-orange-400 hover:-translate-y-0.5 transition-all duration-300 overflow-hidden">
 										<div className="absolute top-0 right-0 w-20 h-20 bg-orange-200/30 rounded-full -translate-x-4 -translate-y-4 blur-lg group-hover:scale-125 transition-transform duration-500" />

--- a/src/app/employees/leaves/page.tsx
+++ b/src/app/employees/leaves/page.tsx
@@ -1,0 +1,439 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+	CheckIcon,
+	XMarkIcon,
+	ArrowPathIcon,
+	CalendarDaysIcon,
+} from '@heroicons/react/24/outline';
+import toast from 'react-hot-toast';
+
+import Navbar from '@/components/Navbar';
+import Sidebar from '@/components/Sidebar';
+import Modal from '@/components/ui/modal';
+import { Button } from '@/components/ui/button';
+import { Input, Textarea } from '@/components/ui/form-fields';
+import {
+	Table,
+	TableHeader,
+	TableBody,
+	TableHead,
+	TableRow,
+	TableCell,
+	TableEmpty,
+} from '@/components/ui/table';
+import { apiGet, apiSend } from '@/lib/api-client';
+import { formatDate } from '@/lib/format';
+import { cn } from '@/lib/cn';
+import { useSessionRBAC } from '@/utils/client-rbac';
+import { RESOURCES, PERMISSIONS } from '@/utils/rbac';
+
+const PAGE_SIZE = 50;
+
+type LeaveStatus = 'pending' | 'approved' | 'rejected';
+
+interface AdminLeaveRow {
+	id: number;
+	user_id: number;
+	applicant_name: string | null;
+	leave_type_name: string;
+	leave_type_code: string;
+	is_paid: number | boolean;
+	start_date: string;
+	end_date: string;
+	half_day: number | boolean;
+	duration_days: string | number;
+	reason: string | null;
+	status: LeaveStatus;
+	reviewer_name: string | null;
+	reviewed_at: string | null;
+	review_notes: string | null;
+}
+
+const STATUS_TABS: Array<{ value: string; label: string }> = [
+	{ value: 'pending', label: 'Pending' },
+	{ value: 'approved', label: 'Approved' },
+	{ value: 'rejected', label: 'Rejected' },
+	{ value: 'all', label: 'All' },
+];
+
+const STATUS_BADGE: Record<string, string> = {
+	pending: 'bg-amber-100 text-amber-700',
+	approved: 'bg-emerald-100 text-emerald-700',
+	rejected: 'bg-red-100 text-red-700',
+};
+
+export default function EmployeeLeavesPage() {
+	const queryClient = useQueryClient();
+	// SessionContext is untyped JS — cast like the reports pages do
+	const { user, can, loading } = useSessionRBAC() as {
+		loading: boolean;
+		user: { id: number; full_name?: string } | null;
+		can: (resource: string, permission: string) => boolean;
+	};
+	const canApprove = can(RESOURCES.LEAVES, PERMISSIONS.APPROVE);
+	const canRead = can(RESOURCES.LEAVES, PERMISSIONS.READ);
+
+	const [statusFilter, setStatusFilter] = useState('pending');
+	const [from, setFrom] = useState('');
+	const [to, setTo] = useState('');
+	const [page, setPage] = useState(1);
+	const [rejectTarget, setRejectTarget] = useState<AdminLeaveRow | null>(null);
+	const [rejectNotes, setRejectNotes] = useState('');
+
+	const listQuery = useQuery<AdminLeaveRow[]>({
+		queryKey: ['admin-leaves', { statusFilter, from, to, page }],
+		queryFn: async () => {
+			const res = await apiGet<{ data?: AdminLeaveRow[] }>('/api/leaves', {
+				status: statusFilter,
+				from,
+				to,
+				page,
+				limit: PAGE_SIZE,
+			});
+			return res.data ?? [];
+		},
+		enabled: !loading && canRead,
+	});
+
+	const reviewMutation = useMutation({
+		mutationFn: async ({
+			id,
+			status,
+			review_notes,
+		}: {
+			id: number;
+			status: LeaveStatus;
+			review_notes?: string;
+		}) => apiSend(`/api/leaves/${id}`, 'PATCH', { status, review_notes }),
+		onSuccess: (_data, variables) => {
+			toast.success(
+				variables.status === 'approved' ? 'Leave approved' : 'Leave rejected'
+			);
+			setRejectTarget(null);
+			setRejectNotes('');
+			queryClient.invalidateQueries({ queryKey: ['admin-leaves'] });
+			queryClient.invalidateQueries({ queryKey: ['leaves'] });
+		},
+		onError: (error: Error) => toast.error(error.message),
+	});
+
+	function approve(row: AdminLeaveRow) {
+		if (
+			window.confirm(
+				`Approve ${row.applicant_name ?? 'this employee'}'s leave (${Number(row.duration_days)} day(s))?`
+			)
+		) {
+			reviewMutation.mutate({ id: row.id, status: 'approved' });
+		}
+	}
+
+	function submitRejection() {
+		if (!rejectTarget) return;
+		if (!rejectNotes.trim()) {
+			toast.error('A reason is required to reject a leave');
+			return;
+		}
+		reviewMutation.mutate({
+			id: rejectTarget.id,
+			status: 'rejected',
+			review_notes: rejectNotes.trim(),
+		});
+	}
+
+	if (!loading && !canRead) {
+		return (
+			<div className="h-screen bg-[var(--page-bg, #fafafa)] flex flex-col overflow-hidden">
+				<Navbar />
+				<Sidebar />
+				<div className="content-with-sidebar flex-1 flex items-center justify-center">
+					<p className="text-sm text-gray-500">
+						You do not have permission to view leave applications.
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="h-screen bg-[var(--page-bg, #fafafa)] flex flex-col overflow-hidden">
+			<Navbar />
+			<Sidebar />
+			<div className="content-with-sidebar flex-1 min-h-0 flex flex-col pt-2 pb-4 px-2 sm:px-4 overflow-hidden">
+				<div className="max-w-full mx-auto w-full flex-1 min-h-0 flex flex-col space-y-4">
+					<header className="flex flex-wrap items-end justify-between gap-3">
+						<div>
+							<h1 className="text-2xl font-bold text-gray-900">
+								Leave Requests
+							</h1>
+							<p className="text-sm text-gray-500 mt-0.5">
+								Review and approve employee leave applications
+							</p>
+						</div>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => listQuery.refetch()}
+							disabled={listQuery.isFetching}
+						>
+							<ArrowPathIcon
+								className={`h-4 w-4 ${listQuery.isFetching ? 'animate-spin' : ''}`}
+							/>
+							Refresh
+						</Button>
+					</header>
+
+					{/* Filters */}
+					<div className="flex flex-wrap items-center gap-2">
+						{STATUS_TABS.map((tab) => (
+							<button
+								key={tab.value}
+								type="button"
+								onClick={() => {
+									setStatusFilter(tab.value);
+									setPage(1);
+								}}
+								className={cn(
+									'px-3 py-1.5 rounded-full text-xs font-semibold transition-colors',
+									statusFilter === tab.value
+										? 'bg-[#64126D] text-white shadow-sm'
+										: 'bg-white text-gray-600 border border-gray-200 hover:border-purple-200 hover:text-[#64126D]'
+								)}
+							>
+								{tab.label}
+							</button>
+						))}
+						<div className="flex items-center gap-1.5 ml-auto">
+							<label className="text-xs text-gray-500">From</label>
+							<Input
+								type="date"
+								value={from}
+								onChange={(e) => {
+									setFrom(e.target.value);
+									setPage(1);
+								}}
+								className="h-8 text-xs w-36"
+							/>
+							<label className="text-xs text-gray-500">To</label>
+							<Input
+								type="date"
+								value={to}
+								onChange={(e) => {
+									setTo(e.target.value);
+									setPage(1);
+								}}
+								className="h-8 text-xs w-36"
+							/>
+						</div>
+					</div>
+
+					{/* Table */}
+					<div className="bg-white rounded-xl shadow-sm border border-gray-200 flex-1 min-h-0 overflow-auto">
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Employee</TableHead>
+									<TableHead>Type</TableHead>
+									<TableHead>Dates</TableHead>
+									<TableHead className="text-right">Days</TableHead>
+									<TableHead>Reason</TableHead>
+									<TableHead>Status</TableHead>
+									<TableHead>Review</TableHead>
+									{canApprove && (
+										<TableHead className="text-right">Actions</TableHead>
+									)}
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{listQuery.isLoading ? (
+									<TableRow>
+										<TableCell {...({ colSpan: canApprove ? 8 : 7 } as object)}>
+											<p className="text-center text-xs text-gray-400 py-6">
+												Loading leave requests…
+											</p>
+										</TableCell>
+									</TableRow>
+								) : (listQuery.data?.length ?? 0) === 0 ? (
+									<TableEmpty colSpan={canApprove ? 8 : 7}>
+										<span className="inline-flex items-center gap-1.5">
+											<CalendarDaysIcon className="w-4 h-4" />
+											No leave applications found.
+										</span>
+									</TableEmpty>
+								) : (
+									(listQuery.data ?? []).map((row) => (
+										<TableRow key={row.id}>
+											<TableCell className="font-medium text-gray-900 whitespace-nowrap">
+												{row.applicant_name ?? `User #${row.user_id}`}
+											</TableCell>
+											<TableCell className="whitespace-nowrap">
+												{row.leave_type_name}
+												<span
+													className={cn(
+														'ml-1.5 inline-flex rounded-full px-1.5 py-0.5 text-[10px] font-semibold',
+														Number(row.is_paid) === 1
+															? 'bg-sky-100 text-sky-700'
+															: 'bg-slate-100 text-slate-600'
+													)}
+												>
+													{Number(row.is_paid) === 1 ? 'Paid' : 'Unpaid'}
+												</span>
+											</TableCell>
+											<TableCell className="whitespace-nowrap text-xs">
+												{formatDate(row.start_date)}
+												{row.start_date !== row.end_date &&
+													` – ${formatDate(row.end_date)}`}
+												{Number(row.half_day) === 1 && (
+													<span className="ml-1 text-[10px] text-gray-400">
+														(half)
+													</span>
+												)}
+											</TableCell>
+											<TableCell className="text-right tabular-nums">
+												{Number(row.duration_days)}
+											</TableCell>
+											<TableCell
+												className="max-w-56 truncate text-xs text-gray-600"
+												title={row.reason ?? ''}
+											>
+												{row.reason ?? '—'}
+											</TableCell>
+											<TableCell>
+												<span
+													className={cn(
+														'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold capitalize',
+														STATUS_BADGE[row.status]
+													)}
+												>
+													{row.status}
+												</span>
+											</TableCell>
+											<TableCell className="text-xs text-gray-600 max-w-48">
+												{row.status !== 'pending' ? (
+													<span title={row.review_notes ?? ''}>
+														{row.reviewer_name ?? '—'}
+														{row.review_notes ? `: ${row.review_notes}` : ''}
+													</span>
+												) : (
+													'—'
+												)}
+											</TableCell>
+											{canApprove && (
+												<TableCell className="text-right whitespace-nowrap">
+													{row.status === 'pending' ? (
+														<div className="inline-flex gap-1">
+															<button
+																type="button"
+																title="Approve"
+																disabled={reviewMutation.isPending}
+																onClick={() => approve(row)}
+																className="p-1.5 rounded-md bg-emerald-50 text-emerald-600 hover:bg-emerald-100 transition-colors disabled:opacity-40"
+															>
+																<CheckIcon className="w-4 h-4" />
+															</button>
+															<button
+																type="button"
+																title="Reject"
+																disabled={reviewMutation.isPending}
+																onClick={() => {
+																	setRejectTarget(row);
+																	setRejectNotes('');
+																}}
+																className="p-1.5 rounded-md bg-red-50 text-red-600 hover:bg-red-100 transition-colors disabled:opacity-40"
+															>
+																<XMarkIcon className="w-4 h-4" />
+															</button>
+														</div>
+													) : row.status === 'approved' ? (
+														<button
+															type="button"
+															title="Revoke approval (reopen as pending)"
+															disabled={reviewMutation.isPending}
+															onClick={() =>
+																reviewMutation.mutate({
+																	id: row.id,
+																	status: 'pending',
+																	review_notes: row.review_notes ?? undefined,
+																})
+															}
+															className="text-[11px] font-medium text-purple-700 hover:underline disabled:opacity-40"
+														>
+															Revoke
+														</button>
+													) : null}
+												</TableCell>
+											)}
+										</TableRow>
+									))
+								)}
+							</TableBody>
+						</Table>
+					</div>
+
+					{/* Pagination */}
+					{listQuery.data && listQuery.data.length === PAGE_SIZE && (
+						<div className="flex items-center justify-end gap-2">
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={page <= 1}
+								onClick={() => setPage((p) => Math.max(1, p - 1))}
+							>
+								Previous
+							</Button>
+							<span className="text-xs text-gray-500">Page {page}</span>
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={(listQuery.data?.length ?? 0) < PAGE_SIZE}
+								onClick={() => setPage((p) => p + 1)}
+							>
+								Next
+							</Button>
+						</div>
+					)}
+				</div>
+			</div>
+
+			{/* Reject modal — mandatory notes */}
+			<Modal
+				open={rejectTarget !== null}
+				onClose={() => setRejectTarget(null)}
+				title="Reject Leave Application"
+				size="sm"
+			>
+				<div className="space-y-3">
+					<p className="text-sm text-gray-600">
+						Rejecting <strong>{rejectTarget?.applicant_name}</strong>&apos;s
+						leave (
+						{rejectTarget
+							? `${formatDate(rejectTarget.start_date)} → ${formatDate(rejectTarget.end_date)}`
+							: ''}
+						). Please provide a reason — it will be shared with the employee.
+					</p>
+					<Textarea
+						rows={3}
+						value={rejectNotes}
+						onChange={(e) => setRejectNotes(e.target.value)}
+						placeholder="Reason for rejection…"
+						required
+					/>
+					<div className="flex justify-end gap-2">
+						<Button variant="outline" onClick={() => setRejectTarget(null)}>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							onClick={submitRejection}
+							disabled={!rejectNotes.trim() || reviewMutation.isPending}
+						>
+							Reject Application
+						</Button>
+					</div>
+				</div>
+			</Modal>
+		</div>
+	);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -887,3 +887,39 @@ textarea::placeholder {
 		animation-delay: 0s !important;
 	}
 }
+
+/* ── Modal entrance (portal-safe, reduced-motion aware) ── */
+@keyframes modal-overlay-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes modal-panel-in {
+	from {
+		opacity: 0;
+		transform: translateY(8px) scale(0.98);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0) scale(1);
+	}
+}
+
+.anim-modal-overlay {
+	animation: modal-overlay-in 0.15s ease-out both;
+}
+
+.anim-modal-panel {
+	animation: modal-panel-in 0.16s cubic-bezier(0.2, 0, 0, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.anim-modal-overlay,
+	.anim-modal-panel {
+		animation: none !important;
+	}
+}

--- a/src/app/user/leaves/page.tsx
+++ b/src/app/user/leaves/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+import Navbar from '@/components/Navbar';
+import LeaveApplications from '@/components/LeaveApplications';
+import { useSession } from '@/context/SessionContext';
+import LoadingSpinner from '@/components/LoadingSpinner';
+
+/**
+ * My Leaves — full leave management for the signed-in user.
+ * Reached from the dashboard's Leaves stat tile.
+ */
+export default function UserLeavesPage() {
+	const router = useRouter();
+	const session = useSession() as {
+		loading: boolean;
+		authenticated: boolean;
+	};
+
+	// Session gate — proxy.ts checks cookie presence only.
+	useEffect(() => {
+		if (!session.loading && !session.authenticated) {
+			router.replace('/signin');
+		}
+	}, [session.loading, session.authenticated, router]);
+
+	return (
+		<div className="min-h-screen bg-gray-50">
+			<Navbar />
+
+			<div className="flex pt-2 sm:pl-16">
+				<div className="flex-1 min-w-0">
+					<div className="pl-0 pr-1 sm:pl-0.5 sm:pr-1.5 lg:pl-1 lg:pr-2 py-2 max-w-6xl mx-auto w-full">
+						<button
+							type="button"
+							onClick={() => router.push('/user/dashboard')}
+							className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-[#64126D] transition-colors rounded-md px-1.5 py-1 -ml-1.5 mb-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#64126D]/40"
+						>
+							<ArrowLeftIcon className="h-4 w-4" aria-hidden />
+							Back to Dashboard
+						</button>
+
+						{session.loading ? (
+							<LoadingSpinner
+								message="Loading your leaves"
+								subMessage="Fetching balances and applications…"
+								showTimer={false}
+								fullScreen={false}
+								size="md"
+							/>
+						) : (
+							<div className="bg-white/80 backdrop-blur-sm rounded-xl border border-gray-200/60 shadow-sm p-3 sm:p-4 xl:p-5">
+								<LeaveApplications />
+							</div>
+						)}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/LeaveApplications.tsx
+++ b/src/components/LeaveApplications.tsx
@@ -1,0 +1,545 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+	useQuery,
+	useMutation,
+	useInfiniteQuery,
+	useQueryClient,
+} from '@tanstack/react-query';
+import {
+	CalendarDaysIcon,
+	PlusIcon,
+	TrashIcon,
+	ArrowPathIcon,
+	ExclamationCircleIcon,
+} from '@heroicons/react/24/outline';
+import toast from 'react-hot-toast';
+
+import Modal from '@/components/ui/modal';
+import { Button } from '@/components/ui/button';
+import {
+	Input,
+	Textarea,
+	Select,
+	FieldGroup,
+} from '@/components/ui/form-fields';
+import {
+	Table,
+	TableHeader,
+	TableBody,
+	TableHead,
+	TableRow,
+	TableCell,
+	TableEmpty,
+} from '@/components/ui/table';
+import { apiGet, apiPost, apiDelete } from '@/lib/api-client';
+import { formatDate } from '@/lib/format';
+import { cn } from '@/lib/cn';
+
+interface LeaveTypeBalance {
+	id: number;
+	name: string;
+	code: string;
+	is_paid: boolean;
+	requires_balance: boolean;
+	quota: number;
+	total: number;
+	used: number;
+	remaining: number;
+}
+
+interface BalancesResponse {
+	success: boolean;
+	data: {
+		year: number;
+		types: LeaveTypeBalance[];
+		totals: { total: number; used: number; balance: number };
+	};
+}
+
+interface LeaveApplication {
+	id: number;
+	start_date: string;
+	end_date: string;
+	half_day: number | boolean;
+	duration_days: number | string;
+	reason: string | null;
+	status: 'pending' | 'approved' | 'rejected';
+	leave_type_name?: string;
+	leave_type_code?: string;
+	is_paid?: number | boolean;
+	review_notes?: string | null;
+	reviewer_name?: string | null;
+}
+
+const PAGE_SIZE = 20;
+
+const STATUS_BADGE: Record<string, string> = {
+	pending: 'bg-amber-100 text-amber-700',
+	approved: 'bg-emerald-100 text-emerald-700',
+	rejected: 'bg-red-100 text-red-700',
+};
+
+/** Mirrors the server-side inclusive day count (see leave-helpers.ts). */
+function clientDuration(
+	startDate: string,
+	endDate: string,
+	halfDay: boolean
+): number {
+	if (!startDate || !endDate) return 0;
+	const start = Date.parse(`${startDate}T00:00:00Z`);
+	const end = Date.parse(`${endDate}T00:00:00Z`);
+	if (Number.isNaN(start) || Number.isNaN(end)) return 0;
+	const days = Math.round((end - start) / 86_400_000) + 1;
+	if (days <= 0) return 0;
+	return halfDay && days === 1 ? 0.5 : days;
+}
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+/**
+ * Full-page "My Leaves" manager — reached from the dashboard Leaves tile.
+ * Balances header, apply dialog, and the complete application history.
+ */
+export default function LeaveApplications() {
+	const queryClient = useQueryClient();
+	const [applyOpen, setApplyOpen] = useState(false);
+	const [form, setForm] = useState({
+		leave_type_id: '',
+		start_date: today(),
+		end_date: today(),
+		half_day: false,
+		reason: '',
+	});
+
+	const balances = useQuery<BalancesResponse['data']>({
+		queryKey: ['leaves', 'balances'],
+		queryFn: async () => {
+			const res = await apiGet<BalancesResponse>('/api/leaves/balances');
+			return res.data;
+		},
+		staleTime: 30_000,
+	});
+
+	const history = useInfiniteQuery<LeaveApplication[]>({
+		queryKey: ['leaves', 'mine'],
+		queryFn: async ({ pageParam }) => {
+			const res = await apiGet<{ data?: LeaveApplication[] }>('/api/leaves', {
+				scope: 'mine',
+				limit: PAGE_SIZE,
+				page: pageParam,
+			});
+			return res.data ?? [];
+		},
+		initialPageParam: 1,
+		getNextPageParam: (lastPage, allPages) =>
+			lastPage.length === PAGE_SIZE ? allPages.length + 1 : undefined,
+		staleTime: 30_000,
+	});
+
+	// All loaded pages flattened, newest-first within each page.
+	const applications = useMemo(
+		() => history.data?.pages.flat() ?? [],
+		[history.data]
+	);
+
+	const applyMutation = useMutation({
+		mutationFn: async () =>
+			apiPost('/api/leaves', {
+				leave_type_id: Number(form.leave_type_id),
+				start_date: form.start_date,
+				end_date: form.end_date,
+				half_day: form.half_day,
+				reason: form.reason,
+			}),
+		onSuccess: () => {
+			toast.success('Leave application submitted');
+			setApplyOpen(false);
+			setForm((f) => ({
+				...f,
+				leave_type_id: '',
+				reason: '',
+				half_day: false,
+			}));
+			queryClient.invalidateQueries({ queryKey: ['leaves'] });
+		},
+		onError: (error: Error) => toast.error(error.message),
+	});
+
+	const withdrawMutation = useMutation({
+		mutationFn: async (id: number) => apiDelete(`/api/leaves/${id}`),
+		onSuccess: () => {
+			toast.success('Application withdrawn');
+			queryClient.invalidateQueries({ queryKey: ['leaves'] });
+		},
+		onError: (error: Error) => toast.error(error.message),
+	});
+
+	const balanceTypes = useMemo(
+		() => balances.data?.types.filter((t) => t.requires_balance) ?? [],
+		[balances.data]
+	);
+
+	const duration = clientDuration(
+		form.start_date,
+		form.end_date,
+		form.half_day
+	);
+	const canSubmit =
+		form.leave_type_id !== '' &&
+		duration > 0 &&
+		form.reason.trim().length > 0 &&
+		!applyMutation.isPending;
+
+	function resetAndClose() {
+		setApplyOpen(false);
+		applyMutation.reset();
+	}
+
+	return (
+		<div className="space-y-4">
+			{/* Header */}
+			<div className="flex flex-wrap items-center justify-between gap-3">
+				<div>
+					<h2 className="text-lg font-bold text-gray-900">My Leaves</h2>
+					<p className="text-sm text-gray-500 mt-0.5">
+						{balances.data
+							? `${balances.data.totals.used} day(s) used · ${balances.data.totals.balance} remaining in ${balances.data.year}`
+							: 'Apply for leave and track your applications'}
+					</p>
+				</div>
+				<Button
+					type="button"
+					size="sm"
+					className="bg-[#64126D] hover:bg-[#52105a] text-white"
+					onClick={() => setApplyOpen(true)}
+				>
+					<PlusIcon className="w-4 h-4 mr-1" />
+					Apply for Leave
+				</Button>
+			</div>
+
+			{/* Balance chips */}
+			{balances.isLoading ? (
+				<div className="flex gap-2" aria-busy>
+					{[0, 1, 2, 3].map((i) => (
+						<div
+							key={i}
+							className="h-16 flex-1 rounded-lg bg-gray-100 animate-pulse"
+						/>
+					))}
+				</div>
+			) : balances.isError ? (
+				<div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2.5 flex items-center gap-2 text-sm text-red-700">
+					<ExclamationCircleIcon className="h-5 w-5 shrink-0" />
+					Could not load balances.
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => balances.refetch()}
+						className="ml-auto"
+					>
+						Retry
+					</Button>
+				</div>
+			) : (
+				balanceTypes.length > 0 && (
+					<div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+						{balanceTypes.map((type) => (
+							<div
+								key={type.id}
+								className={cn(
+									'rounded-lg border px-3 py-2.5 transition-colors',
+									type.remaining === 0
+										? 'border-red-200 bg-red-50'
+										: 'border-purple-100 bg-purple-50/60'
+								)}
+							>
+								<p className="text-[10px] font-bold text-gray-500 uppercase tracking-widest leading-none mb-1 truncate">
+									{type.name}
+								</p>
+								<p className="text-xl font-extrabold leading-tight text-gray-900 tabular-nums">
+									{type.remaining}
+									<span className="text-xs font-semibold text-gray-400 ml-0.5">
+										/ {type.total || type.quota}
+									</span>
+								</p>
+							</div>
+						))}
+					</div>
+				)
+			)}
+
+			{/* Application history */}
+			<div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Dates</TableHead>
+							<TableHead>Type</TableHead>
+							<TableHead className="text-right">Days</TableHead>
+							<TableHead>Reason</TableHead>
+							<TableHead>Status</TableHead>
+							<TableHead>Review</TableHead>
+							<TableHead className="text-right">Actions</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{history.isLoading ? (
+							<TableRow>
+								<TableCell {...({ colSpan: 7 } as object)}>
+									<p className="text-center text-sm text-gray-400 py-8">
+										Loading your applications…
+									</p>
+								</TableCell>
+							</TableRow>
+						) : history.isError ? (
+							<TableRow>
+								<TableCell {...({ colSpan: 7 } as object)}>
+									<div className="flex items-center justify-center gap-2 py-6 text-sm text-red-600">
+										<ExclamationCircleIcon className="h-5 w-5" />
+										Could not load applications.
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() => history.refetch()}
+										>
+											Retry
+										</Button>
+									</div>
+								</TableCell>
+							</TableRow>
+						) : applications.length === 0 ? (
+							<TableEmpty colSpan={7}>
+								<span className="inline-flex items-center gap-1.5">
+									<CalendarDaysIcon className="w-4 h-4" />
+									No leave applications yet — click “Apply for Leave” to submit
+									your first request.
+								</span>
+							</TableEmpty>
+						) : (
+							applications.map((app) => (
+								<TableRow key={app.id}>
+									<TableCell className="whitespace-nowrap text-sm font-medium text-gray-900">
+										{formatDate(app.start_date)}
+										{app.start_date !== app.end_date &&
+											` – ${formatDate(app.end_date)}`}
+										{Number(app.half_day) === 1 && (
+											<span className="ml-1 text-[11px] text-gray-400">
+												(half)
+											</span>
+										)}
+									</TableCell>
+									<TableCell className="whitespace-nowrap text-sm">
+										{app.leave_type_name ?? app.leave_type_code}
+										<span
+											className={cn(
+												'ml-1.5 inline-flex rounded-full px-1.5 py-0.5 text-[10px] font-semibold',
+												Number(app.is_paid) === 1
+													? 'bg-sky-100 text-sky-700'
+													: 'bg-slate-100 text-slate-600'
+											)}
+										>
+											{Number(app.is_paid) === 1 ? 'Paid' : 'Unpaid'}
+										</span>
+									</TableCell>
+									<TableCell className="text-right tabular-nums text-sm">
+										{Number(app.duration_days)}
+									</TableCell>
+									<TableCell
+										className="max-w-56 truncate text-sm text-gray-600"
+										title={app.reason ?? ''}
+									>
+										{app.reason ?? '—'}
+									</TableCell>
+									<TableCell>
+										<span
+											className={cn(
+												'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold capitalize',
+												STATUS_BADGE[app.status] ??
+													'bg-slate-100 text-slate-700'
+											)}
+										>
+											{app.status}
+										</span>
+									</TableCell>
+									<TableCell className="text-xs text-gray-600 max-w-48">
+										{app.status !== 'pending' ? (
+											<span title={app.review_notes ?? ''}>
+												{app.reviewer_name ?? '—'}
+												{app.review_notes ? `: ${app.review_notes}` : ''}
+											</span>
+										) : (
+											'—'
+										)}
+									</TableCell>
+									<TableCell className="text-right">
+										{app.status === 'pending' && (
+											<button
+												type="button"
+												title="Withdraw application"
+												disabled={withdrawMutation.isPending}
+												onClick={() => withdrawMutation.mutate(app.id)}
+												className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-gray-500 hover:text-red-600 hover:bg-red-50 transition-colors disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/40"
+											>
+												{withdrawMutation.isPending ? (
+													<ArrowPathIcon className="h-3.5 w-3.5 animate-spin" />
+												) : (
+													<TrashIcon className="h-3.5 w-3.5" />
+												)}
+												Withdraw
+											</button>
+										)}
+									</TableCell>
+								</TableRow>
+							))
+						)}
+					</TableBody>
+				</Table>
+			</div>
+
+			{history.hasNextPage && (
+				<div className="flex justify-center">
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={history.isFetchingNextPage}
+						onClick={() => history.fetchNextPage()}
+					>
+						{history.isFetchingNextPage ? (
+							<ArrowPathIcon className="h-4 w-4 animate-spin mr-1" />
+						) : null}
+						Load more
+					</Button>
+				</div>
+			)}
+
+			{/* Apply modal */}
+			<Modal
+				open={applyOpen}
+				onClose={resetAndClose}
+				title="Apply for Leave"
+				size="md"
+			>
+				<form
+					className="space-y-3"
+					onSubmit={(e) => {
+						e.preventDefault();
+						if (canSubmit) applyMutation.mutate();
+					}}
+				>
+					<FieldGroup label="Leave type" required>
+						<Select
+							value={form.leave_type_id}
+							onChange={(e) =>
+								setForm((f) => ({
+									...f,
+									leave_type_id: e.target.value,
+									half_day: false,
+								}))
+							}
+							required
+						>
+							<option value="">Select a leave type…</option>
+							{(balances.data?.types ?? []).map((type) => (
+								<option key={type.id} value={type.id}>
+									{type.name}
+									{type.requires_balance ? ` (${type.remaining} left)` : ''}
+								</option>
+							))}
+						</Select>
+					</FieldGroup>
+
+					<div className="grid grid-cols-2 gap-3">
+						<FieldGroup label="From" required>
+							<Input
+								type="date"
+								value={form.start_date}
+								min={today()}
+								onChange={(e) =>
+									setForm((f) => ({
+										...f,
+										start_date: e.target.value,
+										end_date:
+											f.end_date < e.target.value ? e.target.value : f.end_date,
+									}))
+								}
+								required
+							/>
+						</FieldGroup>
+						<FieldGroup label="To" required>
+							<Input
+								type="date"
+								value={form.end_date}
+								min={form.start_date || today()}
+								onChange={(e) =>
+									setForm((f) => ({ ...f, end_date: e.target.value }))
+								}
+								required
+							/>
+						</FieldGroup>
+					</div>
+
+					<div className="flex items-center justify-between gap-2">
+						<label className="inline-flex items-center gap-2 text-xs text-gray-600 cursor-pointer">
+							<input
+								type="checkbox"
+								checked={form.half_day}
+								disabled={form.start_date !== form.end_date}
+								onChange={(e) =>
+									setForm((f) => ({ ...f, half_day: e.target.checked }))
+								}
+								className="rounded border-gray-300 text-[#64126D] focus:ring-[#64126D]"
+							/>
+							Half day
+						</label>
+						<p
+							className={cn(
+								'text-xs font-semibold px-2 py-1 rounded-full tabular-nums',
+								duration > 0
+									? 'bg-purple-50 text-[#64126D]'
+									: 'bg-gray-100 text-gray-400'
+							)}
+						>
+							Duration:{' '}
+							{duration > 0
+								? `${duration} day${duration === 1 ? '' : 's'}`
+								: '—'}
+						</p>
+					</div>
+
+					<FieldGroup label="Reason" required>
+						<Textarea
+							rows={3}
+							value={form.reason}
+							onChange={(e) =>
+								setForm((f) => ({ ...f, reason: e.target.value }))
+							}
+							placeholder="Briefly describe the reason for your leave…"
+							required
+						/>
+					</FieldGroup>
+
+					<div className="flex justify-end gap-2 pt-1">
+						<Button type="button" variant="outline" onClick={resetAndClose}>
+							Cancel
+						</Button>
+						<Button
+							type="submit"
+							disabled={!canSubmit}
+							className="bg-[#64126D] hover:bg-[#52105a] text-white disabled:opacity-50"
+						>
+							{applyMutation.isPending ? (
+								<ArrowPathIcon className="w-4 h-4 mr-1 animate-spin" />
+							) : (
+								<CalendarDaysIcon className="h-4 w-4 mr-1" />
+							)}
+							Submit Application
+						</Button>
+					</div>
+				</form>
+			</Modal>
+		</div>
+	);
+}

--- a/src/components/LeaveLoginToast.tsx
+++ b/src/components/LeaveLoginToast.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+
+import { apiGet } from '@/lib/api-client';
+import {
+	isDecisionToastShown,
+	markDecisionToastShown,
+	pickRecentDecision,
+} from '@/lib/leave-display';
+
+interface LeaveApplicationLite {
+	id: number;
+	status: string;
+	reviewed_at?: string | null;
+	review_notes?: string | null;
+}
+
+/**
+ * Fires a one-time toast on login when a recent leave request was approved
+ * or rejected (see DECISION_WINDOW_DAYS). Renders nothing.
+ *
+ * Shown-once tracking lives in sessionStorage, so the toast re-appears on
+ * the next login/session but never repeats while navigating the app.
+ */
+export default function LeaveLoginToast() {
+	const recent = useQuery<LeaveApplicationLite[]>({
+		queryKey: ['leaves', 'decision-badge'],
+		queryFn: async () => {
+			const res = await apiGet<{ data?: LeaveApplicationLite[] }>(
+				'/api/leaves',
+				{
+					scope: 'mine',
+					limit: 5,
+				}
+			);
+			return res.data ?? [];
+		},
+		staleTime: 60_000,
+	});
+
+	useEffect(() => {
+		if (!recent.data || recent.data.length === 0) return;
+
+		const decision = pickRecentDecision(recent.data);
+		if (!decision || isDecisionToastShown(decision.id)) return;
+		markDecisionToastShown(decision.id);
+
+		const source = recent.data.find((app) => app.id === decision.id);
+		const notes = source?.review_notes?.trim();
+
+		if (decision.kind === 'approved') {
+			toast.success('Your leave request was approved ✅', { duration: 5000 });
+		} else {
+			toast.error(
+				notes
+					? `Your leave request was rejected: ${notes.slice(0, 80)}${notes.length > 80 ? '…' : ''}`
+					: 'Your leave request was rejected',
+				{ duration: 5000 }
+			);
+		}
+	}, [recent.data]);
+
+	return null;
+}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -381,6 +381,18 @@ export default function Sidebar() {
 													Attendance
 												</span>
 											</Link>
+											<Link
+												href="/employees/leaves"
+												className={`group/nav-row flex items-center h-8 rounded-lg px-2.5 text-[12px] font-medium transition-colors ${
+													pathname === '/employees/leaves'
+														? 'bg-purple-100 text-[#64126D]'
+														: 'text-gray-600 hover:bg-purple-50 hover:text-[#64126D]'
+												}`}
+											>
+												<span className="hidden sidebar-open:inline">
+													Leave Requests
+												</span>
+											</Link>
 										</div>
 									)}
 								</>

--- a/src/components/ui/modal.jsx
+++ b/src/components/ui/modal.jsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { cn } from '@/lib/cn';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 
@@ -13,20 +14,53 @@ export default function Modal({
 	size = 'md',
 	dismissible = true,
 }) {
+	const panelRef = useRef(null);
+
 	useEffect(() => {
 		if (!open) return undefined;
+
+		const previouslyFocused = document.activeElement;
+		panelRef.current?.focus?.();
+
 		const onKey = (e) => {
-			if (e.key === 'Escape') onClose?.();
+			if (e.key === 'Escape' && dismissible) {
+				onClose?.();
+				return;
+			}
+			// Lightweight focus trap: wrap Tab within the dialog.
+			if (e.key === 'Tab' && panelRef.current) {
+				const focusables = panelRef.current.querySelectorAll(
+					'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+				);
+				if (focusables.length === 0) return;
+				const first = focusables[0];
+				const last = focusables[focusables.length - 1];
+				if (e.shiftKey && document.activeElement === first) {
+					e.preventDefault();
+					last.focus();
+				} else if (!e.shiftKey && document.activeElement === last) {
+					e.preventDefault();
+					first.focus();
+				}
+			}
 		};
+
 		document.addEventListener('keydown', onKey);
 		document.body.style.overflow = 'hidden';
 		return () => {
 			document.removeEventListener('keydown', onKey);
 			document.body.style.overflow = '';
+			// Restore focus to the trigger that opened the dialog.
+			if (previouslyFocused instanceof HTMLElement) {
+				previouslyFocused.focus();
+			}
 		};
-	}, [open, onClose]);
+	}, [open, onClose, dismissible]);
 
-	if (!open) return null;
+	// Rendered through a portal: an ancestor with backdrop-filter/transform
+	// (e.g. the dashboard's blurred cards) would otherwise become the
+	// containing block for position:fixed and freeze the modal off-screen.
+	if (!open || typeof document === 'undefined') return null;
 
 	const sizeClass =
 		{
@@ -36,16 +70,21 @@ export default function Modal({
 			xl: 'max-w-5xl',
 		}[size] || 'max-w-xl';
 
-	return (
+	return createPortal(
 		<div
-			className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/50 p-4 sm:p-8"
+			className="anim-modal-overlay fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/50 p-4 sm:p-8"
 			onClick={(e) => {
 				if (dismissible && e.target === e.currentTarget) onClose?.();
 			}}
 		>
 			<div
+				ref={panelRef}
+				role="dialog"
+				aria-modal="true"
+				aria-label={title}
+				tabIndex={-1}
 				className={cn(
-					'relative w-full rounded-xl bg-white shadow-2xl ring-1 ring-black/5 my-8',
+					'anim-modal-panel relative w-full rounded-xl bg-white shadow-2xl ring-1 ring-black/5 my-8 outline-none',
 					sizeClass
 				)}
 			>
@@ -54,9 +93,10 @@ export default function Modal({
 					<button
 						type="button"
 						onClick={onClose}
-						className="rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+						aria-label="Close dialog"
+						className="rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#64126D]/40"
 					>
-						<XMarkIcon className="h-4 w-4" />
+						<XMarkIcon className="h-4 w-4" aria-hidden />
 					</button>
 				</div>
 				<div className="px-5 py-4">{children}</div>
@@ -66,6 +106,7 @@ export default function Modal({
 					</div>
 				) : null}
 			</div>
-		</div>
+		</div>,
+		document.body
 	);
 }

--- a/src/components/ui/modal.jsx
+++ b/src/components/ui/modal.jsx
@@ -16,15 +16,29 @@ export default function Modal({
 }) {
 	const panelRef = useRef(null);
 
+	// Latest-handler refs: callers pass inline closures, so onClose's identity
+	// changes on every parent render. Reading them through refs keeps the
+	// open/close effect below dependent ONLY on `open` — otherwise each parent
+	// re-render (e.g. typing in a controlled field inside the modal) would
+	// re-run the effect and yank focus away from the focused input.
+	const onCloseRef = useRef(onClose);
+	onCloseRef.current = onClose;
+	const dismissibleRef = useRef(dismissible);
+	dismissibleRef.current = dismissible;
+
 	useEffect(() => {
 		if (!open) return undefined;
 
-		const previouslyFocused = document.activeElement;
+		const previouslyFocused =
+			document.activeElement instanceof HTMLElement
+				? document.activeElement
+				: null;
 		panelRef.current?.focus?.();
 
 		const onKey = (e) => {
-			if (e.key === 'Escape' && dismissible) {
-				onClose?.();
+			if (e.key === 'Escape' && dismissibleRef.current) {
+				e.stopPropagation();
+				onCloseRef.current?.();
 				return;
 			}
 			// Lightweight focus trap: wrap Tab within the dialog.
@@ -51,11 +65,9 @@ export default function Modal({
 			document.removeEventListener('keydown', onKey);
 			document.body.style.overflow = '';
 			// Restore focus to the trigger that opened the dialog.
-			if (previouslyFocused instanceof HTMLElement) {
-				previouslyFocused.focus();
-			}
+			previouslyFocused?.focus?.();
 		};
-	}, [open, onClose, dismissible]);
+	}, [open]);
 
 	// Rendered through a portal: an ancestor with backdrop-filter/transform
 	// (e.g. the dashboard's blurred cards) would otherwise become the

--- a/src/lib/api-client.d.ts
+++ b/src/lib/api-client.d.ts
@@ -5,3 +5,8 @@ export function apiGet<T = unknown>(
 export function apiPost<T = unknown>(url: string, body?: unknown): Promise<T>;
 export function apiPut<T = unknown>(url: string, body?: unknown): Promise<T>;
 export function apiDelete<T = unknown>(url: string, body?: unknown): Promise<T>;
+export function apiSend<T = unknown>(
+	url: string,
+	method: string,
+	body?: unknown
+): Promise<T>;

--- a/src/lib/leave-display.ts
+++ b/src/lib/leave-display.ts
@@ -1,0 +1,92 @@
+/**
+ * Client-side helpers for leave UI decisions.
+ */
+
+export interface LeaveAppLike {
+	id: number;
+	status: string;
+	reviewed_at?: string | null;
+}
+
+/** How long an approved/rejected decision stays highlighted on the tile. */
+export const DECISION_WINDOW_DAYS = 7;
+
+export type DecisionKind = 'approved' | 'rejected';
+
+export interface RecentDecision {
+	id: number;
+	kind: DecisionKind;
+	/** ISO date the decision was made. */
+	reviewedAt: string;
+}
+
+function toTime(value?: string | null): number | null {
+	if (!value) return null;
+	const t = Date.parse(value);
+	return Number.isNaN(t) ? null : t;
+}
+
+/**
+ * Pick the most recent approved/rejected decision worth surfacing.
+ *
+ * - Ignores pending applications and reviews older than the window.
+ * - Applications are assumed newest-first (API default ordering); among
+ *   reviewed ones the newest reviewed_at wins.
+ *
+ * @param apps       applications, newest-first
+ * @param now        reference time (injectable for tests)
+ */
+export function pickRecentDecision(
+	apps: LeaveAppLike[] | undefined | null,
+	now: Date = new Date()
+): RecentDecision | null {
+	if (!apps || apps.length === 0) return null;
+
+	const windowMs = DECISION_WINDOW_DAYS * 86_400_000;
+	const nowMs = now.getTime();
+	let best: {
+		id: number;
+		kind: DecisionKind;
+		reviewedAt: string;
+		at: number;
+	} | null = null;
+
+	for (const app of apps) {
+		if (app.status !== 'approved' && app.status !== 'rejected') continue;
+		const at = toTime(app.reviewed_at);
+		if (at === null) continue;
+		if (nowMs - at > windowMs) continue;
+		if (!best || at > best.at) {
+			best = {
+				id: app.id,
+				kind: app.status,
+				reviewedAt: app.reviewed_at as string,
+				at,
+			};
+		}
+	}
+
+	return best
+		? { id: best.id, kind: best.kind, reviewedAt: best.reviewedAt }
+		: null;
+}
+
+const TOAST_SHOWN_KEY = 'leaves:decision-toast-shown-id';
+
+/** Has the login toast for this decision already been shown this session? */
+export function isDecisionToastShown(id: number): boolean {
+	try {
+		return window.sessionStorage.getItem(TOAST_SHOWN_KEY) === String(id);
+	} catch {
+		return false;
+	}
+}
+
+/** Remember that the login toast for this decision has been shown. */
+export function markDecisionToastShown(id: number): void {
+	try {
+		window.sessionStorage.setItem(TOAST_SHOWN_KEY, String(id));
+	} catch {
+		/* storage unavailable — worst case the toast repeats on navigation */
+	}
+}

--- a/src/utils/leave-helpers.ts
+++ b/src/utils/leave-helpers.ts
@@ -1,0 +1,275 @@
+/**
+ * Leave system server helpers.
+ *
+ * Shared by /api/leaves routes. The approval side-effects keep three systems
+ * in sync (see migrations/20260825120000_create_leave_system.js):
+ *
+ *  1. leave_applications            — status + written_attendance audit JSON
+ *  2. employee_attendance           — per-date status codes (PL/CL/SL/EL paid,
+ *                                     UL/LWP unpaid, HD half-day) consumed by
+ *                                     src/utils/payroll-calculator.js
+ *  3. employee_leaves               — per-year balance ledger read by
+ *                                     src/app/api/users/[id]/attendance/route.js
+ */
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Max calendar span for a single application. */
+export const MAX_LEAVE_RANGE_DAYS = 365;
+
+/**
+ * Validate a YYYY-MM-DD string and return it, or null when invalid.
+ * @param {unknown} value
+ * @returns {string | null}
+ */
+export function parseDateInput(value) {
+	if (typeof value !== 'string' || !DATE_RE.test(value)) return null;
+	const date = new Date(`${value}T00:00:00Z`);
+	if (Number.isNaN(date.getTime())) return null;
+	// Guard against e.g. 2026-02-31 normalising into March
+	return date.toISOString().slice(0, 10) === value ? value : null;
+}
+
+/**
+ * Inclusive day count between two validated dates. A half-day is only
+ * meaningful for a single-date range and yields 0.5.
+ *
+ * @param {string} startDate YYYY-MM-DD
+ * @param {string} endDate   YYYY-MM-DD
+ * @param {boolean} [halfDay]
+ * @returns {number} positive day count (0.5 steps)
+ */
+export function computeDurationDays(startDate, endDate, halfDay = false) {
+	const start = Date.parse(`${startDate}T00:00:00Z`);
+	const end = Date.parse(`${endDate}T00:00:00Z`);
+	const days = Math.round((end - start) / 86_400_000) + 1;
+	if (days <= 0) return 0;
+	return halfDay && days === 1 ? 0.5 : days;
+}
+
+/**
+ * Split an inclusive date range into per-year calendar day counts so
+ * multi-year approvals hit the right employee_leaves rows.
+ *
+ * @param {string} startDate
+ * @param {string} endDate
+ * @param {boolean} [halfDay]
+ * @returns {Array<{ year: number, days: number }>}
+ */
+export function splitDaysByYear(startDate, endDate, halfDay = false) {
+	if (halfDay) return [{ year: Number(startDate.slice(0, 4)), days: 0.5 }];
+
+	const start = new Date(`${startDate}T00:00:00Z`);
+	const end = new Date(`${endDate}T00:00:00Z`);
+	const segments: Array<{ year: number; days: number }> = [];
+	let cursor = new Date(start);
+
+	while (cursor <= end) {
+		const year = cursor.getUTCFullYear();
+		const yearEnd = Date.UTC(year, 11, 31);
+		const segmentEnd = end.getTime() < yearEnd ? end : new Date(yearEnd);
+		const days =
+			Math.round((segmentEnd.getTime() - cursor.getTime()) / 86_400_000) + 1;
+		segments.push({ year, days });
+		cursor = new Date(Date.UTC(year + 1, 0, 1));
+	}
+	return segments;
+}
+
+function attendanceMarker(applicationId) {
+	return `Leave #${applicationId}`;
+}
+
+/**
+ * Apply an approved leave:
+ *  - writes employee_attendance rows for each working day in range
+ *    (existing presence rows P/HD/OT/WO/H are never overwritten)
+ *  - increments used_leaves per year for types that draw quota
+ *
+ * Returns the audit payload stored on leave_applications.written_attendance.
+ *
+ * @param {import('mysql2/promise').PoolConnection} db transaction connection
+ * @param {{ id: number, user_id: number, employee_id: number, leave_type_id: number,
+ *           start_date: string, end_date: string, half_day: number,
+ *           is_paid: number, code: string }} application joined application row
+ * @param {number} reviewerId
+ * @returns {Promise<{ attendance: Array<{date: string, prev_status: string|null}>,
+ *                     balances: Array<{leave_type_id: number, year: number, days: number}> }>}
+ */
+export async function applyApprovedLeave(db, application, reviewerId) {
+	const { id, employee_id } = application;
+	const startDate = application.start_date.slice(0, 10);
+	const endDate = application.end_date.slice(0, 10);
+	const marker = attendanceMarker(id);
+
+	// Existing rows in range — never clobber real punches / weekly offs / holidays.
+	const [existingRows] = await db.execute(
+		`SELECT attendance_date, status FROM employee_attendance
+     WHERE employee_id = ? AND attendance_date BETWEEN ? AND ?`,
+		[employee_id, startDate, endDate]
+	);
+	const existing = new Map(
+		existingRows.map((row) => [
+			String(row.attendance_date).slice(0, 10),
+			row.status,
+		])
+	);
+
+	// Official holidays inside the range (best effort — table always exists in prod).
+	const holidays = new Set<string>();
+	try {
+		const [holidayRows] = await db.execute(
+			`SELECT holiday_date FROM holiday_master
+       WHERE holiday_date BETWEEN ? AND ?`,
+			[startDate, endDate]
+		);
+		for (const row of holidayRows) {
+			holidays.add(String(row.holiday_date).slice(0, 10));
+		}
+	} catch (_) {
+		/* holiday_master missing — treat every non-Sunday as a working day */
+	}
+
+	// Half-day payroll semantics (payroll-calculator.js):
+	//   'HD' costs 0.5 payable days → correct for unpaid half-days.
+	//   Paid type codes count as full present days → used for paid half-days
+	//   (no salary impact; only the 0.5 balance deduction applies).
+	const singleDay = startDate === endDate;
+	const status =
+		application.half_day && singleDay
+			? application.is_paid
+				? application.code
+				: 'HD'
+			: application.code;
+
+	const appliedAttendance: Array<{
+		date: string;
+		prev_status: string | null;
+	}> = [];
+	const cursor = new Date(`${startDate}T00:00:00Z`);
+	const end = new Date(`${endDate}T00:00:00Z`);
+
+	while (cursor <= end) {
+		const date = cursor.toISOString().slice(0, 10);
+
+		if (cursor.getUTCDay() !== 0 && !holidays.has(date)) {
+			const prevStatus = existing.get(date) ?? null;
+			const normalizedPrev =
+				prevStatus === null || prevStatus === undefined
+					? null
+					: String(prevStatus);
+			const protectedStatus =
+				prevStatus === 'P' ||
+				prevStatus === 'HD' ||
+				prevStatus === 'OT' ||
+				prevStatus === 'WO' ||
+				prevStatus === 'H';
+
+			if (!protectedStatus) {
+				await db.execute(
+					`INSERT INTO employee_attendance
+           (employee_id, attendance_date, status, approved_by, approved_at, remarks)
+         VALUES (?, ?, ?, ?, NOW(), ?)
+         ON DUPLICATE KEY UPDATE
+           status = IF(status IN ('WO', 'H'), status, VALUES(status)),
+           approved_by = VALUES(approved_by),
+           approved_at = NOW(),
+           remarks = VALUES(remarks)`,
+					[employee_id, date, status, reviewerId, marker]
+				);
+				appliedAttendance.push({ date, prev_status: normalizedPrev });
+			}
+		}
+		cursor.setUTCDate(cursor.getUTCDate() + 1);
+	}
+
+	// Balance ledger — only for types that consume quota.
+	const balancesApplied: Array<{
+		leave_type_id: number;
+		year: number;
+		days: number;
+	}> = [];
+	if (application.requires_balance) {
+		for (const segment of splitDaysByYear(
+			startDate,
+			endDate,
+			Boolean(application.half_day)
+		)) {
+			await db.execute(
+				`INSERT INTO employee_leaves (employee_id, leave_type_id, year, total_leaves, used_leaves)
+       VALUES (?, ?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE used_leaves = used_leaves + VALUES(used_leaves)`,
+				[
+					employee_id,
+					application.leave_type_id,
+					segment.year,
+					application.default_annual_quota ?? 0,
+					segment.days,
+				]
+			);
+			balancesApplied.push({
+				leave_type_id: application.leave_type_id,
+				year: segment.year,
+				days: segment.days,
+			});
+		}
+	}
+
+	return { attendance: appliedAttendance, balances: balancesApplied };
+}
+
+/**
+ * Reverse a previously-applied approval (rejection of an approved request or
+ * deletion) using the audit payload persisted in written_attendance.
+ * Restores overwritten statuses, deletes rows this feature created, and
+ * decrements used_leaves (never below zero).
+ *
+ * @param {import('mysql2/promise').PoolConnection} db transaction connection
+ * @param {{ id: number, employee_id: number,
+ *           written_attendance: string|null }} application
+ */
+export async function revertApprovedLeave(db, application) {
+	if (!application.written_attendance) return;
+
+	let audit;
+	try {
+		audit = JSON.parse(application.written_attendance);
+	} catch (_) {
+		return; // corrupt/no audit data — nothing safe to undo
+	}
+	if (!audit || typeof audit !== 'object') return;
+
+	const { id, employee_id } = application;
+	const marker = attendanceMarker(id);
+
+	for (const entry of audit.attendance || []) {
+		if (!entry?.date) continue;
+		if (entry.prev_status === null || entry.prev_status === undefined) {
+			// Row was created by us — remove it only if still carrying our marker.
+			await db.execute(
+				`DELETE FROM employee_attendance
+       WHERE employee_id = ? AND attendance_date = ?
+         AND remarks = ?
+         AND status IN ('PL','CL','SL','EL','UL','LWP','HD')`,
+				[employee_id, entry.date, marker]
+			);
+		} else {
+			await db.execute(
+				`UPDATE employee_attendance
+       SET status = ?, approved_by = NULL, approved_at = NULL, remarks = NULL
+       WHERE employee_id = ? AND attendance_date = ? AND remarks = ?`,
+				[entry.prev_status, employee_id, entry.date, marker]
+			);
+		}
+	}
+
+	for (const segment of audit.balances || []) {
+		if (!segment?.year || !segment.leave_type_id) continue;
+		await db.execute(
+			`UPDATE employee_leaves
+     SET used_leaves = GREATEST(0, used_leaves - ?)
+     WHERE employee_id = ? AND leave_type_id = ? AND year = ?`,
+			[segment.days, employee_id, segment.leave_type_id, segment.year]
+		);
+	}
+}

--- a/src/utils/rbac.js
+++ b/src/utils/rbac.js
@@ -50,6 +50,7 @@ export const RESOURCES = {
 	OTHER_EXPENSES: 'other_expenses',
 	PETTY_CASH_EXPENSES: 'petty_cash_expenses',
 	ATTENDANCE: 'attendance',
+	LEAVES: 'leaves',
 };
 
 export const PERMISSIONS = {
@@ -165,6 +166,14 @@ export const PERMISSION_DESCRIPTIONS = {
 		[PERMISSIONS.CREATE]: 'Create deliverables in the master',
 		[PERMISSIONS.UPDATE]: 'Edit deliverables in the master',
 		[PERMISSIONS.DELETE]: 'Delete deliverables from the master',
+	},
+	[RESOURCES.LEAVES]: {
+		[PERMISSIONS.READ]:
+			'View leave applications (own unless approve is granted)',
+		[PERMISSIONS.CREATE]: 'Apply for leave',
+		[PERMISSIONS.UPDATE]: 'Modify pending leave applications',
+		[PERMISSIONS.DELETE]: 'Withdraw or delete leave applications',
+		[PERMISSIONS.APPROVE]: 'Approve or reject leave applications',
 	},
 };
 


### PR DESCRIPTION
- Migrations: leave_types (codes map to payroll PL/CL/SL/EL/UL/LWP), leave_applications, employee_leaves balance ledger; corrective migration restores roles_master permissions and grants leaves:*
- API: GET/POST /api/leaves, review & withdraw on /api/leaves/[id], GET /api/leaves/balances; approvals write attendance codes and adjust balances in one transaction, revocations reverse via audit JSON
- RBAC: leaves resource (read/create/update/delete/approve) granted to super_admin/project_manager/employee
- User dashboard: clickable Leaves tile -> /user/leaves full-page manager (balances, apply dialog, paginated history, withdraw); login toast for recent approve/reject decisions
- Admin review queue at /employees/leaves (tabs, date filters, reject requires notes) linked from the Employee Master sidebar group
- Modal now renders through a portal so backdrop-filter ancestors no longer freeze fixed dialogs